### PR TITLE
Fix43 47

### DIFF
--- a/polyply/src/linalg_functions.py
+++ b/polyply/src/linalg_functions.py
@@ -145,5 +145,5 @@ def radius_of_gyration(points):
         for j in points:
             diff[count]=np.dot((i - j),(i-j))
             count = count + 1
-    return np.sqrt(1/N**2.0 * sum(diff))
+    return np.sqrt(1/(2*N**2.0) * sum(diff))
 

--- a/polyply/src/random_walk.py
+++ b/polyply/src/random_walk.py
@@ -103,13 +103,13 @@ def update_positions(vector_bundle, meta_molecule, current_node, prev_node):
     prev_vdwr = meta_molecule.volumes[prev_resname]
     vdw_radius, _ = lorentz_berthelot_rule(current_vdwr, prev_vdwr, 1, 1)
 
-    step_length = 2*vdw_radius
-
+    # we give 10 percent more than the vdw radius so we don't generate a
+    # self ovelap
+    step_length = 1.1*vdw_radius
     while True:
         new_point, index = _take_step(vector_bundle, step_length, last_point)
         if not _is_overlap(meta_molecule, new_point, tol=vdw_radius):
             meta_molecule.nodes[current_node]["position"] = new_point
-         #   print(meta_molecule.nodes[current_node]["resname"])
             break
         else:
             vector_bundle = np.delete(vector_bundle, index, axis=0)

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -163,7 +163,7 @@ class Topology(System):
         self.gen_pairs()
         self.replace_defines()
         # only convert if we not already have sig-eps form
-        if self.defaults[0] == 1:
+        if self.defaults['comb-rule'] == 1:
            self.convert_nonbond_to_sig_eps()
 
     def replace_defines(self):

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -162,7 +162,9 @@ class Topology(System):
         """
         self.gen_pairs()
         self.replace_defines()
-        self.convert_nonbond_to_sig_eps()
+        # only convert if we not already have sig-eps form
+        if self.defaults[0] == 1:
+           self.convert_nonbond_to_sig_eps()
 
     def replace_defines(self):
         """
@@ -219,12 +221,12 @@ class Topology(System):
             nb2 = self.nonbond_params[atom_pair]["nb2"]
 
             if nb2 != 0:
-                sig = (nb1/nb2)**(1.0/6.0 )
+                sig = (nb2/nb1)**(1.0/6.0 )
             else:
                 sig = 0
 
             if nb1 != 0:
-                eps = nb2*2.0/(4*nb1)
+                eps = nb1**2.0/(4*nb2)
             else:
                 eps = 0
 

--- a/polyply/tests/test_linalg.py
+++ b/polyply/tests/test_linalg.py
@@ -68,4 +68,4 @@ class TestLinAlg:
                            [0, 0, -1]])
 
         rg = radius_of_gyration(coords)
-        assert math.isclose(rg, np.sqrt(2))
+        assert math.isclose(rg, 1.0)

--- a/polyply/tests/test_topology.py
+++ b/polyply/tests/test_topology.py
@@ -208,5 +208,20 @@ class TestTopology:
         top =  Topology(force_field, name="test")
         polyply.src.top_parser.read_topology(new_lines, top)
         top.replace_defines()
-        print(top.molecules)
         assert top.molecules[0].molecule.interactions["angles"][0].parameters == outcome
+
+    @staticmethod
+    def test_convert_nonbond_to_sig_eps():
+        """
+        Simply test if the conversion from C6 C12 to simga epsilon
+        is done properly.
+        """
+
+        force_field = vermouth.forcefield.ForceField(name='test_ff')
+        top =  Topology(force_field, name="test")
+        top.nonbond_params = {frozenset(["EO", "EO"]):
+                             {"nb1":6.44779031E-02 , "nb2": 4.07588234E-04}}
+        top.convert_nonbond_to_sig_eps()
+        assert math.isclose(top.nonbond_params[frozenset(["EO", "EO"])]["nb1"], 0.43)
+        assert math.isclose(top.nonbond_params[frozenset(["EO", "EO"])]["nb2"], 3.4*0.75)
+


### PR DESCRIPTION
The distances between super CG spheres were very large due to two errors:

1) the conversion of C6 C12 to sigma epsilon was incorrect
2) the radius of gyration was calculated incorrectly