### PR TITLE
Fast apply links

### DIFF
--- a/polyply/src/apply_links.py
+++ b/polyply/src/apply_links.py
@@ -170,7 +170,7 @@ def _assign_link_resids(res_link, match):
     dict that maps the higher resolution nodes to
     the resids specified in` match`. Each `res_link`
     node by definition can only map to one resid provided
-    in `match`. The lower resolution nodes assosicated
+    in `match`. The lower resolution nodes associated
     to a particular res_link node are stored in the 'graph'
     attribute of res_link.
     Note that the nodes in that graph are consecutive

--- a/polyply/src/apply_links.py
+++ b/polyply/src/apply_links.py
@@ -334,12 +334,12 @@ class ApplyLinks(Processor):
                 interaction_key = tuple(new_interaction.atoms) +\
                                   tuple([new_interaction.meta.get("version",1)])
                 self.applied_links[inter_type][interaction_key] = new_interaction
-                # now we already add the edges of this link
-                # links can overwrite each other but the edges must be the same
-                atoms = tuple(interaction.atoms)
-                new_edges = [(link_to_mol[at1], link_to_mol[at2])
-                             for at1, at2 in zip(atoms[:-1], atoms[1:])]
-                molecule.add_edges_from(new_edges)
+        # now we already add the edges of this link
+        # links can overwrite each other but the edges must be the same
+        # this is safer than using the make_edge method because it accounts
+        # for edges written in the edges directive
+        for edge in link.edges:
+            molecule.add_edge(link_to_mol[edge[0]], link_to_mol[edge[1]])
 
     def run_molecule(self, meta_molecule):
         """

--- a/polyply/src/graph_utils.py
+++ b/polyply/src/graph_utils.py
@@ -1,0 +1,42 @@
+# Copyright 2020 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import networkx as nx
+
+def neighborhood(graph, source, max_length, min_length=1):
+    """
+    Returns all neighbours of `source` that are less or equal
+    to `cutoff` nodes away and more or equal to `start` away
+    within a graph excluding the node itself.
+
+    Parameters
+    ----------
+    graph: :class:`networkx.Graph`
+        A networkx graph definintion
+    source:
+        A node key matching one in the graph
+    max_length: :type:`int`
+        The maxdistance between the node and its
+        neighbours.
+    min_length: :type:`int`
+        The minimum length of a path. Default
+        is zero
+
+    Returns
+    --------
+    list
+       list of all nodes distance away from reference
+    """
+    paths = nx.single_source_shortest_path(G=graph, source=source, cutoff=max_length)
+    neighbours = [ node for node, path in paths.items() if min_length <= len(path)]
+    return neighbours

--- a/polyply/src/map_to_molecule.py
+++ b/polyply/src/map_to_molecule.py
@@ -55,7 +55,7 @@ class MapToMolecule(Processor):
         # 1. relable nodes to make space for new nodes to be inserted
         mapping = {}
         offset = len(set(nx.get_node_attributes(block, "resid").values())) - 1
-        print("offset", offset)
+        #print("offset", offset)
         for node in meta_molecule.nodes:
             if node > meta_mol_node:
                 mapping[node] = node + offset

--- a/polyply/src/map_to_molecule.py
+++ b/polyply/src/map_to_molecule.py
@@ -122,10 +122,10 @@ class MapToMolecule(Processor):
             if node + 1 in nx.get_node_attributes(new_mol, "resid").values():
                 continue
             block = force_field.blocks[resname]
-            correspondance = new_mol.merge_molecule(block)
+            correspondence = new_mol.merge_molecule(block)
 
             residue = nx.Graph()
-            for res_node in correspondance.values():
+            for res_node in correspondence.values():
                 data = new_mol.nodes[res_node]
                 residue.add_node(res_node, **data)
 

--- a/polyply/src/map_to_molecule.py
+++ b/polyply/src/map_to_molecule.py
@@ -107,7 +107,8 @@ class MapToMolecule(Processor):
 
         block = force_field.blocks[meta_molecule.nodes[0]["resname"]]
         new_mol = block.to_molecule()
-
+        # we store the block together with the residue node
+        meta_molecule.nodes[0]["block"] = new_mol.copy()
         # TODO: Make a residue graph and check its length instead to make sure
         # you don't get tripped up by e.g. chains and insertion codes.
         if len(set(nx.get_node_attributes(block, "resid").values())) > 1:
@@ -121,7 +122,15 @@ class MapToMolecule(Processor):
             if node + 1 in nx.get_node_attributes(new_mol, "resid").values():
                 continue
             block = force_field.blocks[resname]
-            new_mol.merge_molecule(block)
+            correspondance = new_mol.merge_molecule(block)
+
+            residue = nx.Graph()
+            for res_node in correspondance.values():
+                data = new_mol.nodes[res_node]
+                residue.add_node(res_node, **data)
+
+            meta_molecule.nodes[node]["block"] = residue
+
             if len(set(nx.get_node_attributes(block, "resid").values())) > 1:
                 self.expand_meta_graph(meta_molecule, block, node)
 

--- a/polyply/src/map_to_molecule.py
+++ b/polyply/src/map_to_molecule.py
@@ -108,7 +108,7 @@ class MapToMolecule(Processor):
         block = force_field.blocks[meta_molecule.nodes[0]["resname"]]
         new_mol = block.to_molecule()
         # we store the block together with the residue node
-        meta_molecule.nodes[0]["block"] = new_mol.copy()
+        meta_molecule.nodes[0]["graph"] = new_mol.copy()
         # TODO: Make a residue graph and check its length instead to make sure
         # you don't get tripped up by e.g. chains and insertion codes.
         if len(set(nx.get_node_attributes(block, "resid").values())) > 1:
@@ -129,7 +129,7 @@ class MapToMolecule(Processor):
                 data = new_mol.nodes[res_node]
                 residue.add_node(res_node, **data)
 
-            meta_molecule.nodes[node]["block"] = residue
+            meta_molecule.nodes[node]["graph"] = residue
 
             if len(set(nx.get_node_attributes(block, "resid").values())) > 1:
                 self.expand_meta_graph(meta_molecule, block, node)

--- a/polyply/src/polyply_parser.py
+++ b/polyply/src/polyply_parser.py
@@ -131,7 +131,7 @@ class PolyplyParser(ITPDirector):
        for link in self.force_field.links:
            inter_types = list(link.interactions.keys())
            for inter_type in inter_types:
-               block.make_edges_from_interaction_type(type_=inter_type)
+               link.make_edges_from_interaction_type(type_=inter_type)
 
     # overwrites the finalize method to deal with dangling bonds
     # and to deal with multiple interactions in the way needed

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -242,7 +242,8 @@ class Topology(System):
         """
         for block in self.force_field.blocks.values():
             for inter_type, interactions in block.interactions.items():
-                if inter_type in ["pairs", "exclusions", "virtual_sitesn"]:
+                if inter_type in ["pairs", "exclusions", "virtual_sitesn",
+                                  "virtual_sites2", "virtual_sites3", "virtual_sites4"]:
                     continue
                 for interaction in interactions:
                     if len(interaction.parameters) == 1:

--- a/polyply/tests/test_apply_links.py
+++ b/polyply/tests/test_apply_links.py
@@ -194,6 +194,17 @@ def test_match_link_and_residue_atoms_fail(example_meta_molecule,
                          [(1, 4, 1)],
                          [(0, 0)]
                         ),
+                        # simple check single residue reverse
+                        ([[(0, {'name': 'BB'}),
+                          (1, {'name': 'BB1'})]],
+                         [{0: 1, 1: 0}],
+                         'bonds',
+                         [[vermouth.molecule.Interaction(atoms=(0, 1),
+                                                        parameters=['1', '0.33', '500'],
+                                                        meta={})]],
+                         [(4, 1, 1)],
+                         [(0, 0)]
+                        ),
                         # add replace with node
                         ([[(0, {'name': 'BB1', 'replace': {'charge': 1.0}}),
                           (1, {'name': 'BB'})]],

--- a/polyply/tests/test_apply_links.py
+++ b/polyply/tests/test_apply_links.py
@@ -182,6 +182,18 @@ class TestApplyLinks:
          {0: 'SP2', 1: 'SP2', 2: 'SP2', 3:'SC2'}),
          ("""
          [ link ]
+         [ bonds ]
+	 BB   -BB  1  0.350  1250
+         """,
+         [vermouth.molecule.Interaction(atoms=(1, 2),
+                                        parameters=['1', '0.350', '1250'],
+                                        meta={})],
+         1,
+         [2, 3],
+         'bonds',
+         {0: 'SP2', 1: 'SP2', 2: 'SP2', 3:'SC2'}),
+         ("""
+         [ link ]
          [ atoms ]
          BB  {"replace": {"atype": "P5"}}
          [ bonds ]
@@ -233,6 +245,7 @@ class TestApplyLinks:
         polyply.src.apply_links.apply_link_between_residues(
             new_mol, force_field.links[0], idx)
         assert new_mol.interactions[inttype] == interactions
+        print(new_mol.edges)
         assert len(new_mol.edges) == edges
         assert nx.get_node_attributes(new_mol, "atype") == atypes
 

--- a/polyply/tests/test_apply_links.py
+++ b/polyply/tests/test_apply_links.py
@@ -14,487 +14,385 @@
 """
 Test that force field files are properly read.
 """
-# TODO
-# linting and more unit tests
-
 import textwrap
 import pytest
 import networkx as nx
 import vermouth.forcefield
 import vermouth.ffinput
-from vermouth.molecule import Interaction
-import polyply.src.meta_molecule
-import polyply.src.map_to_molecule
-import polyply.src.polyply_parser
-import polyply.src.apply_links
+from vermouth.molecule import Block, Molecule, Interaction, Link
+import polyply
 from polyply.src.meta_molecule import (MetaMolecule, Monomer)
-from polyply.src.apply_links import MatchError
+from polyply.src.apply_links import MatchError, ApplyLinks
 
 
-class TestApplyLinks:
-    @staticmethod
-    @pytest.mark.parametrize('edges, orders, node, result', (
-        # all ids and within graph
-        ([(0, 1), (1, 2)],
-         [0, 0, 1, 1],
-         1,
-         [[1, 1, 2, 2]]),
-        # all ids but one not in grpah
-        ([(0, 1), (1, 2)],
-         [0, 1, 2, 3],
-         0,
-         [[0, 1, 2, 3]]),
-        # some basic incl. '>'
-        ([(0, 1), (1, 2)],
-         [0, '>', '>'],
-         0,
-         [[0, 1, 1], [0, 2, 2]]),
-        # some basic incl. '<'
-        ([(0, 1), (1, 2)],
-         [0, '<', '<'],
-         2,
-         [[2, 1, 1], [2, 0, 0]]),
-        # some basic incl. '<' but going negative
-        ([(0, 1), (1, 2)],
-         [0, '<', '<'],
-         0,
-         []),
-        # same as above but with explicit order int
-        ([(0, 1), (1, 2)],
-         [0, -1, -1],
-         0,
-         [[0, -1, -1]]),
-        # simple branched case
-        ([(0, 1), (0, 2), (1, 3), (1, 4), (2, 5), (2, 6)],
-         [1, 0, 2],
-         0,
-         [[1, 0, 2]]),
-        # more complex branched case
-        # note that filtering is done later based on sub-graph
-        ([(0, 1), (0, 2), (1, 3), (1, 4), (2, 5), (2, 6)],
-         [1, 0, '>'],
-         0,
-         [[1, 0, 1], [1, 0, 2], [1, 0, 3], [1, 0, 4], [1, 0, 5], [1, 0, 6]]),
-        # linear and some ids some '>'
-        ([(0, 1), (1, 2)],
-         [0, '>', '>>'],
-         0,
-         [[0, 1, 2]]),
-        ([(0, 1), (1, 2), (2, 3), (3, 4)],
-         [0, '<', '>'],
-         2,
-         [[2, 1, 3], [2, 1, 4], [2, 0, 3],
-          [2, 0, 4]]),
-    ))
-    def test_orders_to_paths(edges, orders, node, result):
-        graph = nx.Graph()
-        graph.add_edges_from(edges)
-        paths = polyply.src.apply_links._orders_to_paths(graph, orders, node)
-        assert len(result) == len(paths)
-        for ref_path in result:
-            assert ref_path in paths
+@pytest.mark.parametrize('resids, order, expected',(
+                        ([1, 1, 1], [1, 1, 1], True),
+                        ([1, 2, 3], [1, 1, 1], False),
+                        ([1, 2, 3], [0, 1, 2], True),
+                        ([1, 2, 2], [0, 1, 1], True),
+                        ([1, 2, 3], [0, '>', '>>'], True),
+                        ([1, 2, 3], [0, '>', '>'], False),
+                        ([1, 2, 3], ['<', '<<', 0], False),
+                        ([1, 2, 3], ['<<', '<', 0], True),
+                        ([1, 2, 3], ['<', '<', 0], False)))
+def test_check_relative_orders(resids, order, expected):
+    status = polyply.src.apply_links._check_relative_order(resids, order)
+    assert status == expected
 
-    @staticmethod
-    def test_orders_to_paths_error():
-        graph = nx.Graph()
-        graph.add_edges_from([(0, 1), (1, 2)])
-        with pytest.raises(IOError):
-            polyply.src.apply_links._orders_to_paths(graph, [1, '*'], 0)
+@pytest.mark.parametrize('attributes, ignore, expected',(
+                        ({'resid': 1}, [], [0, 1]),
+                        ({'resid': 1, 'type': 'A'}, [], [0]),
+                        ({'type': 'A'}, [], [0, 2]),
+                        ({}, [], [0, 1, 2, 3]),
+                        ({'name': 'C'}, [], [2, 3]),
+                        ({'order': 1, 'type': 'D'}, ['type'], [2, 3]),
+                        ({'resid': 2, 'name': 'B'}, ['resid'], [1]),
+                        ({'order': 0, 'name': 'A'}, ['name'], [0, 1])))
+def test_find_atoms(attributes, ignore, expected):
+    molecule = nx.Graph()
+    molecule.add_nodes_from([(0 , {'resid': 1, 'order': 0, 'name': 'A', 'type': 'A'}),
+                            (1 , {'resid': 1, 'order': 0, 'name': 'B', 'type': 'B'}),
+                            (2 , {'resid': 2, 'order': 1, 'name': 'C', 'type': 'A'}),
+                            (3 , {'resid': 3, 'order': 1, 'name': 'C', 'type': 'C'})])
+    atoms = polyply.src.apply_links.find_atoms(molecule, ignore=ignore, **attributes)
+    assert set(atoms) == set(expected)
 
-    @staticmethod
-    @pytest.mark.parametrize('edges, orders, node, ref_edges', (
-        # all ids and within graph
-        ([(0, 1), (1, 2)],
-         [0, 0, 1, 1],
-         1,
-         [[(1, 2)]]),
-        # same nodes but split in order sequence
-        ([(0, 1), (1, 2)],
-         [0, 1, 1, 0],
-         1,
-         [[(1, 2)]]),
-        # all ids but one not in grpah
-        ([(0, 1), (1, 2)],
-         [0, 1, 2, 3],
-         0,
-         [[(0, 1), (1, 2), (2, 3)]]),
-        # linear and some ids some '>'
-        ([(0, 1), (1, 2)],
-         [0, '>', '>>'],
-         0,
-         [[(0, 1), (1, 2)], [(0, 2)]])
-    ))
-    def test_gen_link_fragments(edges, orders, node, ref_edges):
-        """
-        Test if the order paths are correctly converted to graphs.
-        All this function really does besides calling order to
-        paths as tested before is to make a graph skipping nodes
-        which are the same.
-        """
-        graph = nx.Graph()
-        graph.add_edges_from(edges)
-        result_graph, _ = polyply.src.apply_links.gen_link_fragments(graph, orders, node)
-        for graph in result_graph:
-            assert list(graph.edges) in ref_edges
+@pytest.fixture
+def example_meta_molecule():
+    """
+    Example molecule with three residues each with
+    different attributes for testing the assignment
+    of links.
 
-    @staticmethod
-    @pytest.mark.parametrize('lines, edge_ref_ids', (
-        ("""
-        [ moleculetype ]
-        ; name nexcl.
-        PEO         1
-        ;
-        [ atoms ]
-        1  SN1a    1   PEO   CO1  1   0.000  45
-        [ link ]
-        resname "PEO"
-        [ bonds ]
-        CO1 +CO1 params
-        """,
-         [[[1, 2], [2, 3]], [[2, 3], [3, 4]],
-          [[3, 4], [4, 5]],
-          [[4, 5]]]),
-        ("""[ moleculetype ]
-        ; name nexcl.
-        PEO         1
-        ;
-        [ atoms ]
-        1  SN1a    1   PEO   CO1  1   0.000  45
-        [ link ]
-        resname "PEO"
-        [ bonds ]
-        -CO1 CO1 params
-        """,
-         [[[1, 2]],
-          [[1, 2], [2, 3]],
-          [[2, 3], [3, 4]],
-          [[3, 4], [4, 5]]]),
-        ("""[ moleculetype ]
-        ; name nexcl.
-        PEO         1
-        ;
-        [ atoms ]
-        1  SN1a    1   PEO   CO1  1   0.000  45
-        [ link ]
-        resname "PEO"
-        [ angles ]
-        CO1 +CO1 ++CO1
-        """,
-         [[[1, 2, 3],
-           [2, 3, 4]],
-          [[2, 3, 4],
-           [3, 4, 5]],
-          [[3, 4, 5]],
-          []]),
-        ("""[ moleculetype ]
-        ; name nexcl.
-        PEO         1
-        ;
-        [ atoms ]
-        1  SN1a    1   PEO   CO1  1   0.000  45
-        [ link ]
-        resname "PEO"
-        [ angles ]
-        --CO1 -CO1 CO1
-        """,
-         [[],
-          [[1, 2, 3]],
-          [[1, 2, 3],
-           [2, 3, 4]],
-          [[2, 3, 4],
-           [3, 4, 5]]]),
-#       ("""[ moleculetype ]
-#       ; name nexcl.
-#       PEO         1
-#       ;
-#       [ atoms ]
-#       1  SN1a    1   PEO   CO1  1   0.000  45
-#       [ link ]
-#       resname "PEO"
-#       [ dihedrals ]
-#       CO1 +CO1 >CO1 >>CO1
-#       """,
-#        [[1, 2, 2, 3], [1, 2, 3, 4], [2, 3, 3, 4],
-#         [2, 3, 4, 5], [3, 4, 4, 5]])
-    ))
-    def test_get_links(lines, edge_ref_ids):
-        lines = textwrap.dedent(lines).splitlines()
-        force_field = vermouth.forcefield.ForceField(name='test_ff')
-        vermouth.ffinput.read_ff(lines, force_field)
-        meta_mol = MetaMolecule.from_monomer_seq_linear(force_field,
-                                                        [Monomer(resname="PEO", n_blocks=5)],
-                                                        "test")
-        polyply.src.map_to_molecule.MapToMolecule().run_molecule(meta_mol)
+    Names:
+    -------
+    BB - BB1 - BB - BB1 - BB2 - BB - BB1
+          |          |                |
+         SC1        SC1              SC1
+          |          |                |
+         SC2        SC2              SC2
 
-        for edge, ref_ids in zip(meta_mol.edges, edge_ref_ids):
-            print(edge)
-            resids = []
-            _, ids = polyply.src.apply_links._get_links(meta_mol, edge)
-            resids += ids
-            print(resids)
-            assert len(resids) == len(ref_ids)
-            for resid in ids:
-                assert resid in ref_ids
+    Nodes:
+    ------
+     0  - 1    4  - 5 - 6   9 - 10
+          |         |           |
+          2         7           11
+          |         |           |
+          3         8           12
+    """
+    force_field = vermouth.forcefield.ForceField("test")
+    block_A = Block(force_field=force_field)
+    block_A.add_nodes_from([(0 , {'resid': 1,  'name': 'BB',  'atype': 'A', 'charge': 0.0, 'other': 'A'}),
+                            (1 , {'resid': 1,  'name': 'BB1', 'atype': 'B', 'charge': 0.0, 'other': 'A'}),
+                            (2 , {'resid': 1,  'name': 'SC1', 'atype': 'C', 'charge': 0.0, 'other': 'A'}),
+                            (3 , {'resid': 1,  'name': 'SC2', 'atype': 'D', 'charge': 1.0, 'other': 'A'})])
+    block_A.add_edges_from([(0, 1), (1, 2), (2, 3)])
 
-#   @staticmethod
-#   @pytest.mark.parametrize('links, interactions, edges, idx, inttype, atypes',
-#        (("""
-#        [ link ]
-#        [ bonds ]
-#        BB +BB  1  0.350  1250
-#        """,
-#        [vermouth.molecule.Interaction(atoms=(0, 1),
-#                                       parameters=['1', '0.350', '1250'],
-#                                       meta={})],
-#        1,
-#        [1, 2],
-#        'bonds',
-#        {0: 'SP2', 1: 'SP2', 2: 'SP2', 3: 'SC2'}),
-#        ("""
-#        [ link ]
-#        [ bonds ]
-#        BB   SC1   1  0.350  1250
-#        """,
-#        [vermouth.molecule.Interaction(atoms=(2, 3),
-#                                       parameters=['1', '0.350', '1250'],
-#                                       meta={})],
-#        1,
-#        [3, 3],
-#        'bonds',
-#        {0: 'SP2', 1: 'SP2', 2: 'SP2', 3:'SC2'}),
-#        ("""
-#        [ link ]
-#        [ bonds ]
-#        BB   -BB  1  0.350  1250
-#        """,
-#        [vermouth.molecule.Interaction(atoms=(1, 2),
-#                                       parameters=['1', '0.350', '1250'],
-#                                       meta={})],
-#        1,
-#        [2, 3],
-#        'bonds',
-#        {0: 'SP2', 1: 'SP2', 2: 'SP2', 3:'SC2'}),
-#        ("""
-#        [ link ]
-#        [ atoms ]
-#        BB  {"replace": {"atype": "P5"}}
-#        [ bonds ]
-#        BB   SC1   1  0.350  1250
-#        """,
-#        [vermouth.molecule.Interaction(atoms=(2, 3),
-#                                       parameters=['1', '0.350', '1250'],
-#                                       meta={})],
-#        1,
-#        [3, 3],
-#        'bonds',
-#        {0: 'SP2', 1: 'SP2', 2: 'P5', 3: 'SC2'}),
-#        ("""
-#        [ link ]
-#        [ angles ]
-#        BB  +BB  +SC1  1  125  250
-#        """,
-#       [vermouth.molecule.Interaction(atoms=(1, 2, 3),
-#                                      parameters=['1', '125', '250'],
-#                                      meta={})],
-#       2,
-#       [2, 3],
-#       'angles',
-#       {0: 'SP2', 1: 'SP2', 2: 'SP2', 3: 'SC2'})
-#       ))
-#   def test_add_interaction_and_edge(links, interactions, edges, idx, inttype, atypes):
-#       lines = """
-#       [ moleculetype ]
-#       GLY  1
-#       [ atoms ]
-#       ;id  type resnr residu atom cgnr   charge
-#        1   SP2   1     GLY    BB     1      0
-#       [ moleculetype ]
-#       ALA  1
-#       [ atoms ]
-#       ;id  type resnr residu atom cgnr   charge
-#        1   SP2   1     ALA    BB     1      0
-#        2   SC2   1     ALA    SC1     1      0
-#       """
-#       lines = lines + links
-#       lines = textwrap.dedent(lines).splitlines()
-#       force_field = vermouth.forcefield.ForceField(name='test_ff')
-#       vermouth.ffinput.read_ff(lines, force_field)
+    block_B = Block(force_field=force_field)
+    block_B.add_nodes_from([(0 , {'resid': 1,  'name': 'BB', 'atype': 'A', 'charge': 0.0}),
+                            (1 , {'resid': 1,  'name': 'BB1', 'atype': 'B', 'charge': 0.0}),
+                            (2 , {'resid': 1,  'name': 'BB2', 'atype': 'A', 'charge': 0.0}),
+                            (3 , {'resid': 1,  'name': 'SC1', 'atype': 'A', 'charge': -0.5}),
+                            (4 , {'resid': 1,  'name': 'SC2', 'atype': 'C', 'charge': 0.5})])
+    block_B.add_edges_from([(0, 1), (1, 2), (2, 3), (1, 4)])
 
-#       new_mol = force_field.blocks['GLY'].to_molecule()
-#       new_mol.merge_molecule(force_field.blocks['GLY'])
-#       new_mol.merge_molecule(force_field.blocks['ALA'])
+    molecule = block_A.to_molecule()
+    molecule.merge_molecule(block_B)
+    molecule.merge_molecule(block_A)
+    molecule.add_edges_from([(1, 4), (8, 9)])
 
-#       polyply.src.apply_links.apply_link_between_residues(new_mol,
-#                                                           force_field.links[0],
-#                                                           idx)
-#       assert new_mol.interactions[inttype] == interactions
-#       assert len(new_mol.edges) == edges
-#       assert nx.get_node_attributes(new_mol, "atype") == atypes
+    graph = MetaMolecule._block_graph_to_res_graph(molecule)
+    meta_mol = MetaMolecule(graph, force_field=force_field, mol_name="test")
+    # before do links is called there are no edges between the residues
+    # at lower level
+    molecule.remove_edges_from([(1, 4), (8, 9)])
+    meta_mol.molecule = molecule
+    return meta_mol
 
-#   @staticmethod
-#   @pytest.mark.parametrize('links, idx',(
-#      (  # no match considering the order parameter
-#                                    """
-#        [ link ]
-#        [ bonds ]
-#        BB   +BB  1  0.350  1250""",
-#        [1, 4],
-#      ),
-#      (  # no match due to incorrect atom name
-#                                    """
-#        [ link ]
-#        [ bonds ]
-#        BB   SC5   1  0.350  1250
-#        """,
-#       [3, 3])))
-#   def test_link_failure(links, idx):
-#       lines = """
-#       [ moleculetype ]
-#       GLY  1
-#       [ atoms ]
-#       ;id  type resnr residu atom cgnr   charge
-#        1   SP2   1     GLY    BB     1      0
-#       [ moleculetype ]
-#       ALA  1
-#       [ atoms ]
-#       ;id  type resnr residu atom cgnr   charge
-#        1   SP2   1     ALA    BB     1      0
-#        2   SC2   1     ALA    SC1    1      0
-#       """
-#       lines = lines + links
-#       lines = textwrap.dedent(lines).splitlines()
-#       force_field = vermouth.forcefield.ForceField(name='test_ff')
-#       vermouth.ffinput.read_ff(lines, force_field)
+@pytest.mark.parametrize('link_nodes, link_to_resid, expected',(
+                        # first and second residue name-based
+                        ([(0, {'name': 'BB1'}),
+                          (1, {'name': 'BB'})],
+                          {0: 0, 1: 1},
+                          {0: 1, 1: 4}
+                        ),
+                        # second third residue name-based
+                        ([(0, {'name': 'BB2'}),
+                          (1, {'name': 'BB'})],
+                          {0: 1, 1: 2},
+                          {0: 6, 1: 9}
+                        ),
+                        # third and first residue name-based
+                        ([(0, {'name': 'BB'}),
+                          (1, {'name': 'BB1'})],
+                          {0: 0, 1: 2},
+                          {0: 0, 1: 10}
+                        ),
+                        # selection type based
+                        ([(0, {'name': 'BB', 'atype': 'A'}),
+                          (1, {'atype': 'B'})],
+                          {0: 0, 1: 2},
+                          {0: 0, 1: 10}
+                        ),
+                        ))
+def test_match_link_and_residue_atoms(example_meta_molecule,
+                                      link_nodes,
+                                      link_to_resid,
+                                      expected):
 
-#       new_mol = force_field.blocks['GLY'].to_molecule()
-#       new_mol.merge_molecule(force_field.blocks['GLY'])
-#       new_mol.merge_molecule(force_field.blocks['ALA'])
+    link = nx.Graph()
+    link.add_nodes_from(link_nodes)
+    match = polyply.src.apply_links.match_link_and_residue_atoms(example_meta_molecule,
+                                                                 link,
+                                                                 link_to_resid)
+    assert match == expected
 
-#       with pytest.raises(MatchError):
-#           polyply.src.apply_links.apply_link_between_residues(
-#               new_mol, force_field.links[0], idx)
+@pytest.mark.parametrize('link_nodes, link_to_resid',(
+                        # one non-matching name
+                        ([(0, {'name': 'QB1'}),
+                          (1, {'name': 'BB'})],
+                          {0: 0, 1: 1}
+                        ),
+                        # both names not matching
+                        ([(0, {'name': 'QB2'}),
+                          (1, {'name': 'QB'})],
+                          {0: 1, 1: 2}
+                        ),
+                        # one additional attribute not matching
+                        ([(0, {'name': 'BB', 'atype': 'Q'}),
+                          (1, {'name': 'BB1', 'charge': -1})],
+                          {0: 0, 1: 2}
+                        ),
+                        # more than one matching atom
+                        ([(0, {'atype': 'A'}),
+                          (1, {'other': 'A'})],
+                          {0: 0, 1: 2}
+                        ),
+                        ))
+def test_match_link_and_residue_atoms_fail(example_meta_molecule,
+                                      link_nodes,
+                                      link_to_resid):
 
-    @staticmethod
-    @pytest.mark.parametrize('links, interactions, edges, inttype',(
-       ("""
-       [ link ]
-       [ molmeta ]
-       by_atom_ID true
-       [ bonds ]
-       1   2  1  0.350  1250
-       """,
-       [vermouth.molecule.Interaction(atoms=(0, 1),
-                                      parameters=['1', '0.350', '1250'],
-                                      meta={})],
-       1,
-       'bonds'
-       ),
-       ("""
-       [ link ]
-       [ molmeta ]
-       by_atom_ID true
-       [ angles ]
-       2  3  4  1  125  250
-       """,
-       [vermouth.molecule.Interaction(atoms=(1, 2, 3),
-                                      parameters=['1', '125', '250'],
-                                      meta={})],
-       2,
-       'angles')
-       ))
-    def test_add_explicit_link(links, interactions, edges, inttype):
-        lines = """
-        [ moleculetype ]
-        GLY  1
-        [ atoms ]
-        ;id  type resnr residu atom cgnr   charge
-         1   SP2   1     GLY    BB     1      0
-        [ moleculetype ]
-        ALA  1
-        [ atoms ]
-        ;id  type resnr residu atom cgnr   charge
-         1   SP2   1     ALA    BB     1      0
-         2   SC2   1     ALA    SC1     1      0
-        """
-        lines = lines + links
-        lines = textwrap.dedent(lines).splitlines()
-        force_field = vermouth.forcefield.ForceField(name='test_ff')
-        vermouth.ffinput.read_ff(lines, force_field)
+    link = nx.Graph()
+    link.add_nodes_from(link_nodes)
+    with pytest.raises(polyply.src.apply_links.MatchError):
+         polyply.src.apply_links.match_link_and_residue_atoms(example_meta_molecule,
+                                                              link,
+                                                              link_to_resid)
 
-        new_mol = force_field.blocks['GLY'].to_molecule()
-        new_mol.merge_molecule(force_field.blocks['GLY'])
-        new_mol.merge_molecule(force_field.blocks['ALA'])
+@pytest.mark.parametrize('link_defs, link_to_resids, inter_type, link_inters, expected_nodes, expected_inters',
+                        (
+                        # simple check single residue
+                        ([[(0, {'name': 'BB1'}),
+                          (1, {'name': 'BB'})]],
+                         [{0: 0, 1: 1}],
+                         'bonds',
+                         [[vermouth.molecule.Interaction(atoms=(0, 1),
+                                                        parameters=['1', '0.33', '500'],
+                                                        meta={})]],
+                         [(1, 4, 1)],
+                         [(0, 0)]
+                        ),
+                        # add replace with node
+                        ([[(0, {'name': 'BB1', 'replace': {'charge': 1.0}}),
+                          (1, {'name': 'BB'})]],
+                         [{0: 0, 1: 1}],
+                         'bonds',
+                         [[vermouth.molecule.Interaction(atoms=(0, 1),
+                                                        parameters=['1', '0.33', '500'],
+                                                        meta={})]],
+                         [(1, 4, 1)],
+                         [(0, 0)]
+                        ),
+                      # test multiple versions don't overwrite
+                        ([[(0, {'name': 'BB1', 'replace': {'charge': 1.0}}),
+                          (1, {'name': 'BB'})]],
+                         [{0: 0, 1: 1}],
+                         'bonds',
+                         [[vermouth.molecule.Interaction(atoms=(0, 1),
+                                                        parameters=['1', '0.33', '500'],
+                                                        meta={"version": 1}),
+                          vermouth.molecule.Interaction(atoms=(0, 1),
+                                                        parameters=['1', '0.33', '600'],
+                                                        meta={"version": 2})]],
+                          [(1, 4, 1), (1, 4, 2)],
+                          [(0, 0), (0, 1)]
+                        ),
+                      # test multiple links which don't overwrite
+                        ([[(0, {'name': 'BB1', 'replace': {'charge': 1.0}}),
+                           (1, {'name': 'BB'})],
+                         [(0, {'name': 'BB2'}), (1, {'name': 'BB'})]],
+                         [{0: 0, 1: 1},
+                          {0: 1, 1: 2}],
+                         'bonds',
+                         [[vermouth.molecule.Interaction(atoms=(0, 1),
+                                                        parameters=['1', '0.33', '500'],
+                                                        meta={"version": 1})],
+                          [vermouth.molecule.Interaction(atoms=(0, 1),
+                                                        parameters=['1', '0.33', '600'],
+                                                        meta={"version": 1})]],
+                          [(1, 4, 1), (6, 9, 1)],
+                          [(0, 0), (1, 0)]
+                        ),
+                      # test multiple links which do overwrite
+                        ([[(0, {'name': 'BB1'}), (1, {'name': 'BB'})],
+                          [(0, {'name': 'BB1'}), (1, {'name': 'BB'})]],
+                         [{0: 0, 1: 1},
+                          {0: 0, 1: 1}],
+                         'bonds',
+                         [[vermouth.molecule.Interaction(atoms=(0, 1),
+                                                        parameters=['1', '0.33', '500'],
+                                                        meta={"version": 1})],
+                          [vermouth.molecule.Interaction(atoms=(0, 1),
+                                                        parameters=['1', '0.33', '600'],
+                                                        meta={"version": 1})]],
+                          [(1, 4, 1)],
+                          [(1, 0)]
+                        ),
+                        ))
+def test_apply_link_to_residue(example_meta_molecule,
+                               link_defs,
+                               link_to_resids,
+                               inter_type,
+                               link_inters,
+                               expected_nodes,
+                               expected_inters):
+    links = []
+    processor = ApplyLinks()
+    for link_nodes, link_to_resid, interactions in zip(link_defs,
+                                                       link_to_resids,
+                                                       link_inters):
+        link = Link()
+        link.add_nodes_from(link_nodes)
+        link.interactions[inter_type] = interactions
+        processor.apply_link_between_residues(example_meta_molecule,
+                                              link,
+                                              link_to_resid)
 
+    for nodes, inter_idx in zip(expected_nodes, expected_inters):
+        interaction = link_inters[inter_idx[0]][inter_idx[1]]
+        new_interactions = processor.applied_links[inter_type][nodes]
+        assert new_interactions.atoms == tuple(nodes[:-1])
+        assert new_interactions.parameters == interaction.parameters
+        assert new_interactions.meta == interaction.meta
+
+
+@pytest.mark.parametrize('links, interactions, edges, inttype',(
+   ("""
+   [ link ]
+   [ molmeta ]
+   by_atom_ID true
+   [ bonds ]
+   1   2  1  0.350  1250
+   """,
+   [vermouth.molecule.Interaction(atoms=(0, 1),
+                                  parameters=['1', '0.350', '1250'],
+                                  meta={})],
+   1,
+   'bonds'
+   ),
+   ("""
+   [ link ]
+   [ molmeta ]
+   by_atom_ID true
+   [ angles ]
+   2  3  4  1  125  250
+   """,
+   [vermouth.molecule.Interaction(atoms=(1, 2, 3),
+                                  parameters=['1', '125', '250'],
+                                  meta={})],
+   2,
+   'angles')
+   ))
+def test_add_explicit_link(links, interactions, edges, inttype):
+    lines = """
+    [ moleculetype ]
+    GLY  1
+    [ atoms ]
+    ;id  type resnr residu atom cgnr   charge
+     1   SP2   1     GLY    BB     1      0
+    [ moleculetype ]
+    ALA  1
+    [ atoms ]
+    ;id  type resnr residu atom cgnr   charge
+     1   SP2   1     ALA    BB     1      0
+     2   SC2   1     ALA    SC1     1      0
+    """
+    lines = lines + links
+    lines = textwrap.dedent(lines).splitlines()
+    force_field = vermouth.forcefield.ForceField(name='test_ff')
+    vermouth.ffinput.read_ff(lines, force_field)
+
+    new_mol = force_field.blocks['GLY'].to_molecule()
+    new_mol.merge_molecule(force_field.blocks['GLY'])
+    new_mol.merge_molecule(force_field.blocks['ALA'])
+
+    polyply.src.apply_links.apply_explicit_link(
+        new_mol, force_field.links[0])
+    assert new_mol.interactions[inttype] == interactions
+    assert len(new_mol.edges) == edges
+
+@pytest.mark.parametrize('links, error_type',
+                         (("""
+     [ link ]
+     [ molmeta ]
+     by_atom_ID true
+     [ bonds ]
+     BB  +BB  1  0.350  1250
+     """,
+                           ValueError
+                           ),
+                          ("""
+     [ link ]
+     [ molmeta ]
+     by_atom_ID true
+     [ angles ]
+     1   8  1  125  250
+     """,
+                           IOError)
+                          ))
+def test_explicit_link_failure(links, error_type):
+    lines = """
+    [ moleculetype ]
+    GLY  1
+    [ atoms ]
+    ;id  type resnr residu atom cgnr   charge
+     1   SP2   1     GLY    BB     1      0
+    [ moleculetype ]
+    ALA  1
+    [ atoms ]
+    ;id  type resnr residu atom cgnr   charge
+     1   SP2   1     ALA    BB     1      0
+     2   SC2   1     ALA    SC1    1      0
+    """
+    lines = lines + links
+    lines = textwrap.dedent(lines).splitlines()
+    force_field = vermouth.forcefield.ForceField(name='test_ff')
+    vermouth.ffinput.read_ff(lines, force_field)
+
+    new_mol = force_field.blocks['GLY'].to_molecule()
+    new_mol.merge_molecule(force_field.blocks['GLY'])
+    new_mol.merge_molecule(force_field.blocks['ALA'])
+
+    with pytest.raises(error_type):
         polyply.src.apply_links.apply_explicit_link(
             new_mol, force_field.links[0])
-        assert new_mol.interactions[inttype] == interactions
-        assert len(new_mol.edges) == edges
 
-    @staticmethod
-    @pytest.mark.parametrize('links, error_type',
-                             (("""
-         [ link ]
-         [ molmeta ]
-         by_atom_ID true
-         [ bonds ]
-         BB  +BB  1  0.350  1250
-         """,
-                               ValueError
-                               ),
-                              ("""
-         [ link ]
-         [ molmeta ]
-         by_atom_ID true
-         [ angles ]
-         1   8  1  125  250
-         """,
-                               IOError)
-                              ))
-    def test_explicit_link_failure(links, error_type):
-        lines = """
-        [ moleculetype ]
-        GLY  1
-        [ atoms ]
-        ;id  type resnr residu atom cgnr   charge
-         1   SP2   1     GLY    BB     1      0
-        [ moleculetype ]
-        ALA  1
-        [ atoms ]
-        ;id  type resnr residu atom cgnr   charge
-         1   SP2   1     ALA    BB     1      0
-         2   SC2   1     ALA    SC1    1      0
-        """
-        lines = lines + links
-        lines = textwrap.dedent(lines).splitlines()
-        force_field = vermouth.forcefield.ForceField(name='test_ff')
-        vermouth.ffinput.read_ff(lines, force_field)
-
-        new_mol = force_field.blocks['GLY'].to_molecule()
-        new_mol.merge_molecule(force_field.blocks['GLY'])
-        new_mol.merge_molecule(force_field.blocks['ALA'])
-
-        with pytest.raises(error_type):
-            polyply.src.apply_links.apply_explicit_link(
-                new_mol, force_field.links[0])
-    @staticmethod
-    def test_expand_exclusions():
-        mol = vermouth.Molecule()
-        mol.nrexcl = 1
-        mol.add_edges_from([(0, 1), (1, 2), (2, 3), (2, 4)])
-        nx.set_node_attributes(mol, {0:1, 1:2, 2:2, 3:2, 4:2}, "exclude")
-        mol = polyply.src.apply_links.expand_excl(mol)
-        ref_excl = [frozenset([0, 1]),
-                    frozenset([1, 2]),
-                    frozenset([2, 0]),
-                    frozenset([2, 3]),
-                    frozenset([2, 4]),
-                    frozenset([3, 4]),
-                    frozenset([3, 1]),
-                    frozenset([4, 1])]
-        print(mol.interactions["exclusions"])
-        assert len(ref_excl) == len(mol.interactions["exclusions"])
-        for excl in mol.interactions["exclusions"]:
-            assert frozenset(excl.atoms) in ref_excl
-
-
-
+def test_expand_exclusions():
+    mol = vermouth.Molecule()
+    mol.nrexcl = 1
+    mol.add_edges_from([(0, 1), (1, 2), (2, 3), (2, 4)])
+    nx.set_node_attributes(mol, {0:1, 1:2, 2:2, 3:2, 4:2}, "exclude")
+    mol = polyply.src.apply_links.expand_excl(mol)
+    ref_excl = [frozenset([0, 1]),
+                frozenset([1, 2]),
+                frozenset([2, 0]),
+                frozenset([2, 3]),
+                frozenset([2, 4]),
+                frozenset([3, 4]),
+                frozenset([3, 1]),
+                frozenset([4, 1])]
+    print(mol.interactions["exclusions"])
+    assert len(ref_excl) == len(mol.interactions["exclusions"])
+    for excl in mol.interactions["exclusions"]:
+        assert frozenset(excl.atoms) in ref_excl

--- a/polyply/tests/test_apply_links.py
+++ b/polyply/tests/test_apply_links.py
@@ -175,6 +175,7 @@ def test_match_link_and_residue_atoms_fail(example_meta_molecule,
 
     link = nx.Graph()
     link.add_nodes_from(link_nodes)
+
     with pytest.raises(polyply.src.apply_links.MatchError):
          polyply.src.apply_links.match_link_and_residue_atoms(example_meta_molecule,
                                                               link,
@@ -392,7 +393,7 @@ def test_expand_exclusions():
                 frozenset([3, 4]),
                 frozenset([3, 1]),
                 frozenset([4, 1])]
-    print(mol.interactions["exclusions"])
+
     assert len(ref_excl) == len(mol.interactions["exclusions"])
     for excl in mol.interactions["exclusions"]:
         assert frozenset(excl.atoms) in ref_excl

--- a/polyply/tests/test_data/gen_itp/input/test.ff
+++ b/polyply/tests/test_data/gen_itp/input/test.ff
@@ -1,0 +1,53 @@
+; Copyright 2020 University of Groningen
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;    http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+;;; N1
+ 
+[ moleculetype ]
+; molname       nrexcl
+N1            1
+
+[ atoms ]
+;id  type resnr residu atom cgnr   charge
+ 1   N1   1      N1     BB     1      0
+
+;;; N2
+
+[ moleculetype ]
+; molname       nrexcl
+N2            1
+
+[ atoms ]
+;id  type resnr residu atom cgnr   charge
+ 1   N2   1      N2     BB     1      0
+
+;;; N3
+
+[ moleculetype ]
+; molname       nrexcl
+N3            1
+
+[ atoms ]
+;id  type resnr residu atom cgnr   charge
+ 1   N3   1      N3     BB     1      0
+
+[ link ]
+resname "N1|N2"
+[ bonds ]
+BB +BB 1 0.350 1250 {"group": "inner"}
+
+[ link ]
+resname "N2|N3"
+[ bonds ]
+-BB  BB 1 0.250 1250 {"group": "outer"}

--- a/polyply/tests/test_data/gen_itp/ref/test_rev.itp
+++ b/polyply/tests/test_data/gen_itp/ref/test_rev.itp
@@ -1,0 +1,35 @@
+; Copyright 2020 University of Groningen
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;    http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+
+; polyply-itp
+
+[ moleculetype ]
+testref 1
+
+[ atoms ]
+ 1 N1  1 N1 BB  1 0.0 
+ 2 N1  2 N1 BB  2 0.0 
+ 3 N2  3 N2 BB  3 0.0 
+ 4 N2  4 N2 BB  4 0.0 
+ 5 N2  5 N2 BB  5 0.0 
+
+[ bonds ]
+; inner
+ 1  2 1 0.350 1250
+ 2  3 1 0.350 1250
+ 3  4 1 0.350 1250
+
+; outer
+ 4  5 1 0.250 1250

--- a/polyply/tests/test_graph_utils.py
+++ b/polyply/tests/test_graph_utils.py
@@ -1,0 +1,32 @@
+# Copyright 2020 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test graph related functions
+"""
+import pytest
+import networkx as nx
+import polyply
+
+@pytest.mark.parametrize('source, max_length, min_length, expected',(
+                        (4, 1, 1, [4, 1, 9, 10]),
+                        (4, 2, 1, [4, 1, 9, 10, 0, 3]),
+                        (4, 3, 3, [0, 3, 7, 8, 2]),
+                        ))
+def test_neighbourhood(source, max_length, min_length, expected):
+    graph = nx.balanced_tree(r=2, h=3)
+    neighbours = polyply.src.graph_utils.neighborhood(graph,
+                                                      source,
+                                                      max_length,
+                                                      min_length=min_length)
+    assert set(neighbours) == set(expected)

--- a/polyply/tests/test_itp_gen.py
+++ b/polyply/tests/test_itp_gen.py
@@ -44,7 +44,12 @@ class TestGenItp():
          "-seqf", TEST_DATA + "/gen_itp/input/PPI.json",
          "-name", "PPI",
          "-o", TEST_DATA + "/gen_itp/output/PPI_out.itp"],
-         TEST_DATA + "/gen_itp/ref/G3.itp")
+         TEST_DATA + "/gen_itp/ref/G3.itp"),
+        (["-f", TEST_DATA + "/gen_itp/input/test.ff",
+         "-seq", "N1:1", "N2:1", "N1:1", "N2:1", "N3:1",
+         "-name", "test",
+         "-o", TEST_DATA + "/gen_itp/output/test_out.itp"],
+         TEST_DATA + "/gen_itp/ref/test_rev.itp")
         ))
     def test_gen_itp(args_in, ref_file):
         parser = argparse.ArgumentParser(

--- a/polyply/tests/test_polyply_input.py
+++ b/polyply/tests/test_polyply_input.py
@@ -172,4 +172,5 @@ class TestPolyply:
             key = list(link.interactions.keys())[0]
             values = link.interactions[key]
             print(values)
-            assert len(values) == 1 
+            assert len(values) == 1
+            assert len(link.edges) != 0

--- a/polyply/tests/test_topology.py
+++ b/polyply/tests/test_topology.py
@@ -508,6 +508,62 @@ class TestTopology:
         test 1
         """,
         {"bonds": [Interaction(atoms=(0, 1), parameters=["1", "0.1335", "502080.0"], meta={})]}
+        ),
+        # test virtual_sites n,2,3,4 are skipped
+        (
+        """
+        #define _FF_OPLS
+        [ defaults ]
+        1.0   1.0   yes  1.0     1.0
+        [ atomtypes ]
+        opls_001   C   6      12.01100     0.500       A    3.75000e-01  4.39320e-01 ; SIG
+        [ bondtypes ]
+        C       C       1       0.1335  502080.0
+        [ moleculetype ]
+        test 3
+        [ atoms ]
+        1 opls_001   1 test C1 1   0.0 14.0
+        2 opls_001   1 test C2 2   0.0 12.0
+        3 opls_001   1 test C2 2   0.0 12.0
+        4 opls_001   1 test C2 2   0.0 12.0
+        5 opls_001   1 test C2 2   0.0 12.0
+        6 opls_001   1 test C2 2   0.0 12.0
+        7 opls_001   1 test C2 2   0.0 12.0
+        8 opls_001   1 test C2 2   0.0 12.0
+        9 opls_001   1 test C2 2   0.0 12.0
+        10 opls_001   1 test C2 2   0.0 12.0
+        [ bonds ]
+        1  2  1
+        1  8  1
+        1  9  1
+        2  9  1
+        8  9  1
+        ; currently not parsed accurately due to vermouth bug
+        ;[ virtual_sites2 ]
+        ;4   1  9  1  0.5000
+        [ virtual_sites3 ]
+        5   4  8  1  1  0.200  0.200
+        6   4  9  2  1  0.200  0.200
+        [ virtual_sites4 ]
+        10   4  8  1  7  1  0.200  0.200  0.300
+        [ virtual_sitesn ]
+        3   1   4   4   1  2
+        7   1   4   4   8  9
+        [ system ]
+        some title
+        [ molecules ]
+        test 1
+        """,
+        {"bonds": [Interaction(atoms=(0, 1), parameters=["1", "0.1335", "502080.0"], meta={}),
+                   Interaction(atoms=(0, 7), parameters=["1", "0.1335", "502080.0"], meta={}),
+                   Interaction(atoms=(0, 8), parameters=["1", "0.1335", "502080.0"], meta={}),
+                   Interaction(atoms=(1, 8), parameters=["1", "0.1335", "502080.0"], meta={}),
+                   Interaction(atoms=(7, 8), parameters=["1", "0.1335", "502080.0"], meta={})],
+         "virtual_sitesn": [Interaction(atoms=(2, 3, 3, 0, 1), parameters=["1"], meta={}),
+                            Interaction(atoms=(6, 3, 3, 7, 8), parameters=["1"], meta={})],
+         "virtual_sites4": [Interaction(atoms=(9, 3, 7, 0, 6), parameters=["1", "0.200", "0.200", "0.300"], meta={})],
+         "virtual_sites3": [Interaction(atoms=(4, 3, 7, 0), parameters=["1", "0.200", "0.200"], meta={}),
+                            Interaction(atoms=(5, 3, 8, 1), parameters=["1", "0.200", "0.200"], meta={})]}
         )
 	))
     def test_replace_types(lines, outcome):

--- a/polyply/tests/test_topology.py
+++ b/polyply/tests/test_topology.py
@@ -539,8 +539,8 @@ class TestTopology:
         2  9  1
         8  9  1
         ; currently not parsed accurately due to vermouth bug
-        ;[ virtual_sites2 ]
-        ;4   1  9  1  0.5000
+        [ virtual_sites2 ]
+        4   1  9  1  0.5000
         [ virtual_sites3 ]
         5   4  8  1  1  0.200  0.200
         6   4  9  2  1  0.200  0.200
@@ -562,6 +562,7 @@ class TestTopology:
          "virtual_sitesn": [Interaction(atoms=(2, 3, 3, 0, 1), parameters=["1"], meta={}),
                             Interaction(atoms=(6, 3, 3, 7, 8), parameters=["1"], meta={})],
          "virtual_sites4": [Interaction(atoms=(9, 3, 7, 0, 6), parameters=["1", "0.200", "0.200", "0.300"], meta={})],
+         "virtual_sites2": [Interaction(atoms=(3, 0, 8), parameters=["1", "0.5000"], meta={})],
          "virtual_sites3": [Interaction(atoms=(4, 3, 7, 0), parameters=["1", "0.200", "0.200"], meta={}),
                             Interaction(atoms=(5, 3, 8, 1), parameters=["1", "0.200", "0.200"], meta={})]}
         )

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,3 +3,4 @@ coverage
 pytest-cov
 pylint
 codecov
+tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install-requires =  # ?? requires-dist?
     networkx ~= 2.0
     vermouth
     scipy
+    tqdm
 zip-safe = False
 
 


### PR DESCRIPTION
This PR bases apply links on a graph iso-morphism search at residue level, which fixes issue #78 . In addition it instead of looping over all interactions when one interaction is added newly, it first cashes them in a dict and overwrites interactions that have the same atom sequence and version. Furthermore it when looking up matching atoms it doesn't search the complete molecule anymore but just the residue corresponding to the meta-molecule node. Overall this cuts run-time by a factor of about 200 in complex cases. 