### PR TITLE
Fix/map molecule

### DIFF
--- a/polyply/src/graph_utils.py
+++ b/polyply/src/graph_utils.py
@@ -40,3 +40,23 @@ def neighborhood(graph, source, max_length, min_length=1):
     paths = nx.single_source_shortest_path(G=graph, source=source, cutoff=max_length)
     neighbours = [ node for node, path in paths.items() if min_length <= len(path)]
     return neighbours
+
+def is_branched(graph):
+    """
+    Check if any node has a degree larger than 2
+
+    Parameters:
+    -----------
+    graph: :class:`networkx.Graph`
+        A networkx graph definintion
+
+    Returns:
+    --------
+    bool
+       is branched
+    """
+    degrees = nx.degree(graph, nbunch=(graph.nodes))
+    for node, deg in degrees:
+        if deg > 2:
+           return True
+    return False

--- a/polyply/src/graph_utils.py
+++ b/polyply/src/graph_utils.py
@@ -55,8 +55,7 @@ def is_branched(graph):
     bool
        is branched
     """
-    degrees = nx.degree(graph, nbunch=(graph.nodes))
-    for node, deg in degrees:
+    for node, deg in graph.degree:
         if deg > 2:
            return True
     return False

--- a/polyply/src/map_to_molecule.py
+++ b/polyply/src/map_to_molecule.py
@@ -60,11 +60,12 @@ class MapToMolecule(Processor):
                            "virtual_sites2", "virtual_sites3", "virtual_sites4"]:
             block.make_edges_from_interaction_type(inter_type)
 
-        # 1. make residue graph and check it is not branched
-        # we cannot do branched block expansion
+        # 1. make residue graph
         expanded_graph = make_residue_graph(block)
 
-        # 2. clear out all old edges
+        # 2. clear out all old edges, because the
+        # inserted part will not have any edges with the
+        # rest of the meta_molecule as we don't know those
         old_edges = list(meta_molecule.edges(meta_mol_node))
         meta_molecule.remove_edges_from(old_edges)
 

--- a/polyply/src/map_to_molecule.py
+++ b/polyply/src/map_to_molecule.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import networkx as nx
+from vermouth.graph_utils import (make_residue_graph,
+                                  collect_residues)
 from polyply.src.processor import Processor
+from polyply.src.graph_utils import is_branched
 
 def tag_exclusions(blocks, force_field):
     """
@@ -52,48 +55,41 @@ class MapToMolecule(Processor):
         residues are added instead of the orignial block to
         the meta molecule.
         """
-        # 1. relable nodes to make space for new nodes to be inserted
+        # 0. make edges for the block
+        for inter_type in ["bonds", "constraints", "virtual_sitesn",
+                           "virtual_sites2", "virtual_sites3", "virtual_sites4"]:
+            block.make_edges_from_interaction_type(inter_type)
+
+        # 1. make residue graph and check it is not branched
+        # we cannot do branched block expansion
+        expanded_graph = make_residue_graph(block)
+        if is_branched(expanded_graph):
+            msg = ("Block {} consists of more than one residue, however, "
+                   "it is branched. Cannot expand a branched block, because "
+                   "of lacking information on how the block connects to the "
+                   "rest.")
+            raise IOError(msg.format(block.name))
+
+        # 2. relable nodes to make space for new nodes to be inserted
         mapping = {}
-        offset = len(set(nx.get_node_attributes(block, "resid").values())) - 1
-        #print("offset", offset)
+        offset = len(expanded_graph.nodes) - 1
         for node in meta_molecule.nodes:
             if node > meta_mol_node:
                 mapping[node] = node + offset
 
         nx.relabel_nodes(meta_molecule, mapping, copy=False)
+        # 3. add the new nodes to the meta molecule overwriting
+        # the inital nodes inserting the graph
+        nodes = list(expanded_graph.nodes)
+        nodes.sort()
+        for node in nodes:
+            node_key = node + meta_mol_node
+            attrs = expanded_graph.nodes[node]
+            attrs.update({"links": False})
+            meta_molecule.add_node(node_key, **attrs)
 
-        # 2. add the new nodes to the meta molecule overwriting
-        # the inital node
-        node_to_resid = {}
-        resids = nx.get_node_attributes(block, "resid")
-        for node, resid in resids.items():
-            if resid != meta_mol_node:
-                node_to_resid[node] = resid + meta_mol_node - 1
-            else:
-                node_to_resid[node] = resid
-
-        #print(node_to_resid)
-        meta_molecule.add_nodes_from(set(node_to_resid.values()))
-
-        # 3. set node attributes
-        name_dict = {}
-        ignore_dict = {}
-        resnames = nx.get_node_attributes(block, "resname")
-        for idx, value in resnames.items():
-            name_dict.update({node_to_resid[idx]:value})
-            ignore_dict.update({node_to_resid[idx]:False})
-
-        nx.set_node_attributes(meta_molecule, name_dict, "resname")
-        nx.set_node_attributes(meta_molecule, ignore_dict, "links")
-
-        # 4. add all missing edges
-        block.make_edges_from_interaction_type(type_="bonds")
-        #print(block.edges)
-        for edge in block.edges:
-            v1 = node_to_resid[edge[0]]
-            v2 = node_to_resid[edge[1]]
-            if v1 != v2:
-                meta_molecule.add_edge(v1, v2)
+        for edge in expanded_graph.edges:
+            meta_molecule.add_edge(edge[0] + meta_mol_node, edge[1] + meta_mol_node)
 
     def add_blocks(self, meta_molecule):
         """
@@ -111,7 +107,8 @@ class MapToMolecule(Processor):
         meta_molecule.nodes[0]["graph"] = new_mol.copy()
         # TODO: Make a residue graph and check its length instead to make sure
         # you don't get tripped up by e.g. chains and insertion codes.
-        if len(set(nx.get_node_attributes(block, "resid").values())) > 1:
+        res_dict = collect_residues(block, attrs=('resid', 'resname'))
+        if len(res_dict) > 1:
             self.expand_meta_graph(meta_molecule, block, 0)
 
         node_keys = list(meta_molecule.nodes.keys())
@@ -131,7 +128,8 @@ class MapToMolecule(Processor):
 
             meta_molecule.nodes[node]["graph"] = residue
 
-            if len(set(nx.get_node_attributes(block, "resid").values())) > 1:
+            res_dict = collect_residues(block, attrs=('resid', 'resname'))
+            if len(res_dict) > 1:
                 self.expand_meta_graph(meta_molecule, block, node)
 
         return new_mol
@@ -150,4 +148,5 @@ class MapToMolecule(Processor):
         """
         new_molecule = self.add_blocks(meta_molecule)
         meta_molecule.molecule = new_molecule
+        #print(meta_molecule.nodes(data=True))
         return meta_molecule

--- a/polyply/tests/test_graph_utils.py
+++ b/polyply/tests/test_graph_utils.py
@@ -30,3 +30,19 @@ def test_neighbourhood(source, max_length, min_length, expected):
                                                       max_length,
                                                       min_length=min_length)
     assert set(neighbours) == set(expected)
+
+@pytest.mark.parametrize('edges, expected',(
+                        # simple linear
+                        ([(0, 1), (1, 2), (2, 3)], False),
+                        # simple cyclic
+                        ([(0, 1), (1, 2), (2, 3), (3, 0)], False),
+                        # simple branched
+                        ([(0, 1), (1, 2), (1, 3), (3, 4)], True),
+                        # cyclic branched
+                        ([(0, 1), (1, 2), (2, 3), (3, 0), (0, 5)], True),
+                        ))
+def test_is_branched(edges, expected):
+    graph = nx.Graph()
+    graph.add_edges_from(edges)
+    result = polyply.src.graph_utils.is_branched(graph)
+    assert result == expected

--- a/polyply/tests/test_graph_utils.py
+++ b/polyply/tests/test_graph_utils.py
@@ -40,6 +40,8 @@ def test_neighbourhood(source, max_length, min_length, expected):
                         ([(0, 1), (1, 2), (1, 3), (3, 4)], True),
                         # cyclic branched
                         ([(0, 1), (1, 2), (2, 3), (3, 0), (0, 5)], True),
+                        # no nodes
+                        ([], False)
                         ))
 def test_is_branched(edges, expected):
     graph = nx.Graph()

--- a/polyply/tests/test_map_to_molecule.py
+++ b/polyply/tests/test_map_to_molecule.py
@@ -65,8 +65,9 @@ class TestMapToMolecule:
         assert new_meta_mol.molecule.interactions['bonds'] == bonds
 
     @staticmethod
-    def test_multiresidue_block():
-        lines = """
+    @pytest.mark.parametrize('lines, monomers, bonds, edges, nnodes, resnames', (
+        # linear multiblock last
+        ("""
         [ moleculetype ]
         ; name nexcl.
         PEO         1
@@ -87,27 +88,106 @@ class TestMapToMolecule:
         1  2   1   0.37 7000
         2  3   1   0.37 7000
         3  4   1   0.37 7000
+        """,
+        ["PEO", "MIX"],
+        [Interaction(atoms=(1, 2), parameters=['1', '0.37', '7000'], meta={}),
+         Interaction(atoms=(2, 3), parameters=['1', '0.37', '7000'], meta={}),
+         Interaction(atoms=(3, 4), parameters=['1', '0.37', '7000'], meta={})],
+        [(1, 2)],
+        3,
+        {0: "PEO", 1: "R1", 2: "R2"}),
+        # linear multi-block second
+        ("""
+        [ moleculetype ]
+        ; name nexcl.
+        PEO         1
+        ;
+        [ atoms ]
+        1  SN1a    1   PEO   CO1  1   0.000  45
+        [ moleculetype ]
+        ; name nexcl.
+        MIX         1
+        ;
+        [ atoms ]
+        1  SN1a    1   R1   C1  1   0.000  45
+        2  SN1a    1   R1   C2  1   0.000  45
+        3  SC1     2   R2   C1  2   0.000  45
+        4  SC1     2   R2   C2  2   0.000  45
+        [ bonds ]
+        ; back bone bonds
+        1  2   1   0.37 7000
+        2  3   1   0.37 7000
+        3  4   1   0.37 7000
+        """,
+        ["MIX", "PEO"],
+        [Interaction(atoms=(0, 1), parameters=['1', '0.37', '7000'], meta={}),
+         Interaction(atoms=(1, 2), parameters=['1', '0.37', '7000'], meta={}),
+         Interaction(atoms=(2, 3), parameters=['1', '0.37', '7000'], meta={})],
+        [(0, 1)],
+        3,
+        {0: "R1", 1: "R2", 2: "PEO"}),
+        # linear branched
+        ("""
+        [ moleculetype ]
+        ; name nexcl.
+        PEO         1
+        ;
+        [ atoms ]
+        1  SN1a    1   PEO   CO1  1   0.000  45
+        [ moleculetype ]
+        ; name nexcl.
+        MIX         1
+        ;
+        [ atoms ]
+        1  SN1a    1   R1   C1  1   0.000  45
+        2  SC1     1   R1   C1  2   0.000  45
+        3  SN1a    2   R2   C1  1   0.000  45
+        4  SC1     2   R2   C1  2   0.000  45
+        5  SN1a    3   R3   C1  1   0.000  45
+        6  SC1     3   R3   C1  2   0.000  45
+        7  SN1a    4   R2   C1  1   0.000  45
+        8  SC1     4   R2   C1  2   0.000  45
+        [ bonds ]
+        ; back bone bonds
+        1  2   1   0.44 7000
+        1  3   1   0.37 7000
+        3  4   1   0.44 7000
+        3  5   1   0.37 7000
+        3  7   1   0.37 7000
+        5  6   1   0.44 7000
+        7  8   1   0.44 7000
+        """,
+        ["PEO", "MIX"],
+        [Interaction(atoms=(1, 2), parameters=['1', '0.44', '7000'], meta={}),
+         Interaction(atoms=(1, 3), parameters=['1', '0.37', '7000'], meta={}),
+         Interaction(atoms=(3, 4), parameters=['1', '0.44', '7000'], meta={}),
+         Interaction(atoms=(3, 5), parameters=['1', '0.37', '7000'], meta={}),
+         Interaction(atoms=(3, 7), parameters=['1', '0.37', '7000'], meta={}),
+         Interaction(atoms=(5, 6), parameters=['1', '0.44', '7000'], meta={}),
+         Interaction(atoms=(7, 8), parameters=['1', '0.44', '7000'], meta={})],
+        [(1, 2), (2, 3), (2, 4)],
+        5,
+        {0: "PEO", 1: "R1", 2: "R2", 3: "R3", 4: "R2"})
+))
+    def test_multiresidue_block(lines, monomers, bonds, edges, nnodes, resnames):
+        """
+        Test if a linear molecule of multiple residues is exanded,
+        correctly into a multi-block residue.
         """
         lines = textwrap.dedent(lines).splitlines()
         ff = vermouth.forcefield.ForceField(name='test_ff')
         polyply.src.polyply_parser.read_polyply(lines, ff)
         meta_mol = MetaMolecule(name="test", force_field=ff)
-        meta_mol.add_monomer(0,"PEO",[])
-        meta_mol.add_monomer(1,"MIX",[(1,0)])
+        meta_mol.add_monomer(0, monomers[0], [])
+        meta_mol.add_monomer(1, monomers[1], [(1,0)])
 
         new_meta_mol = polyply.src.map_to_molecule.MapToMolecule().run_molecule(meta_mol)
 
-        bonds = [Interaction(atoms=(1, 2), parameters=['1', '0.37', '7000'], meta={}),
-                 Interaction(atoms=(2, 3), parameters=['1', '0.37', '7000'], meta={}),
-                 Interaction(atoms=(3, 4), parameters=['1', '0.37', '7000'], meta={})]
-
-        edges = [(0,1), (1,2)]
-
         assert new_meta_mol.molecule.interactions['bonds'] == bonds
-        assert len(new_meta_mol.nodes) == 3
+        assert len(new_meta_mol.nodes) == nnodes
         assert list(new_meta_mol.edges) == edges
-        assert nx.get_node_attributes(new_meta_mol, "resname") == {0: "PEO", 1: "R1", 2: "R2"}
-
+        assert nx.get_node_attributes(new_meta_mol, "resname") == resnames
+        assert len(nx.get_node_attributes(new_meta_mol, "graph")) == nnodes
 
     @staticmethod
     def test_multi_excl_block():


### PR DESCRIPTION
Currently the expansion of multi-residue blocks doesn't work because they don't get the graph attribute. So now I make a residue graph and add it instead of the previous home-brew. Also there is a check for branched molecules and a fixed ToDO. Only thing left is adding some more unit tests. 