### PR TITLE
More link definitions for building block copolymers

### DIFF
--- a/polyply/data/martini2_polymers/links.ff
+++ b/polyply/data/martini2_polymers/links.ff
@@ -47,3 +47,8 @@ resname "PEO|OHter"
 resname "PEO|PE"
 [ bonds ]
 COC  +CH2            1       0.45  7000  {"group": "PE-PEO"}
+
+[ link ]
+resname "PE|PEO"
+[ bonds ]
+CH2  +COC            1       0.45  7000  {"group": "PEO-PE"}

--- a/polyply/tests/test_data/gen_itp/input/PEO_PE.json
+++ b/polyply/tests/test_data/gen_itp/input/PEO_PE.json
@@ -1,0 +1,95 @@
+{
+  "directed": false,
+  "multigraph": false,
+  "graph": {},
+  "nodes": [
+    {
+      "resname": "PEO",
+      "seqid": 0,
+      "id": 0
+    },
+    {
+      "resname": "PE",
+      "seqid": 0,
+      "id": 1
+    },
+    {
+      "resname": "PEO",
+      "seqid": 0,
+      "id": 2
+    },
+    {
+      "resname": "PE",
+      "seqid": 0,
+      "id": 3
+    },
+    {
+      "resname": "PEO",
+      "seqid": 0,
+      "id": 4
+    },
+    {
+      "resname": "PEO",
+      "seqid": 0,
+      "id": 5
+    },
+    {
+      "resname": "PE",
+      "seqid": 0,
+      "id": 6
+    },
+    {
+      "resname": "PE",
+      "seqid": 0,
+      "id": 7
+    },
+    {
+      "resname": "PEO",
+      "seqid": 0,
+      "id": 8
+    },
+    {
+      "resname": "PE",
+      "seqid": 0,
+      "id": 9
+    }
+  ],
+  "links": [
+    {
+      "source": 0,
+      "target": 1
+    },
+    {
+      "source": 1,
+      "target": 2
+    },
+    {
+      "source": 2,
+      "target": 3
+    },
+    {
+      "source": 3,
+      "target": 4
+    },
+    {
+      "source": 4,
+      "target": 5
+    },
+    {
+      "source": 5,
+      "target": 6
+    },
+    {
+      "source": 6,
+      "target": 7
+    },
+    {
+      "source": 7,
+      "target": 8
+    },
+    {
+      "source": 8,
+      "target": 9
+    }
+  ]
+}

--- a/polyply/tests/test_data/gen_itp/output/PEO_b_PE_out.itp
+++ b/polyply/tests/test_data/gen_itp/output/PEO_b_PE_out.itp
@@ -1,0 +1,35 @@
+; polyply-itp
+
+[ moleculetype ]
+PEO_PE 1
+
+[ atoms ]
+ 1 EO  1 PEO COC  1 0.0 45.0
+ 2 C1  2 PE  CH2  2 0.0 45.0
+ 3 EO  3 PEO COC  3 0.0 45.0
+ 4 C1  4 PE  CH2  4 0.0 45.0
+ 5 EO  5 PEO COC  5 0.0 45.0
+ 6 EO  6 PEO COC  6 0.0 45.0
+ 7 C1  7 PE  CH2  7 0.0 45.0
+ 8 C1  8 PE  CH2  8 0.0 45.0
+ 9 EO  9 PEO COC  9 0.0 45.0
+10 C1 10 PE  CH2 10 0.0 45.0
+
+[ bonds ]
+ 5  6 1 0.322 7000
+ 7  8 1 0.46 2000
+
+; PE-PEO
+ 1  2 1 0.45 7000
+ 3  4 1 0.45 7000
+ 6  7 1 0.45 7000
+ 9 10 1 0.45 7000
+
+; PEO-PE
+ 2  3 1 0.45 7000
+ 4  5 1 0.45 7000
+ 8  9 1 0.45 7000
+
+[ exclusions ]
+ 7  8 
+

--- a/polyply/tests/test_data/gen_itp/ref/PEO_PE_10.itp
+++ b/polyply/tests/test_data/gen_itp/ref/PEO_PE_10.itp
@@ -1,0 +1,35 @@
+; polyply-itp
+
+[ moleculetype ]
+PEO_PEref 1
+
+[ atoms ]
+ 1 EO  1 PEO COC  1 0.0 45.0
+ 2 C1  2 PE  CH2  2 0.0 45.0
+ 3 EO  3 PEO COC  3 0.0 45.0
+ 4 C1  4 PE  CH2  4 0.0 45.0
+ 5 EO  5 PEO COC  5 0.0 45.0
+ 6 EO  6 PEO COC  6 0.0 45.0
+ 7 C1  7 PE  CH2  7 0.0 45.0
+ 8 C1  8 PE  CH2  8 0.0 45.0
+ 9 EO  9 PEO COC  9 0.0 45.0
+10 C1 10 PE  CH2 10 0.0 45.0
+
+[ bonds ]
+ 5  6 1 0.322 7000
+ 7  8 1 0.46 2000
+
+; PE-PEO
+ 1  2 1 0.45 7000
+ 3  4 1 0.45 7000
+ 6  7 1 0.45 7000
+ 9 10 1 0.45 7000
+
+; PEO-PE
+ 2  3 1 0.45 7000
+ 4  5 1 0.45 7000
+ 8  9 1 0.45 7000
+
+[ exclusions ]
+ 7  8 
+

--- a/polyply/tests/test_itp_gen.py
+++ b/polyply/tests/test_itp_gen.py
@@ -62,7 +62,12 @@ class TestGenItp():
          "-seq", "OHter:1", "PEO:26", "OHter:1",
          "-name", "PEOM2",
          "-o", TEST_DATA + "/gen_itp/output/PEOM2_out.itp"],
-         TEST_DATA + "/gen_itp/ref/PEOM2.itp")
+         TEST_DATA + "/gen_itp/ref/PEOM2.itp"),
+        (["-lib", "martini2_polymers",
+         "-seqf", TEST_DATA + "/gen_itp/input/PEO_PE.json",
+         "-name", "PEO_PE",
+         "-o", TEST_DATA + "/gen_itp/output/PEO_b_PE_out.itp"],
+         TEST_DATA + "/gen_itp/ref/PEO_PE_10.itp")
         ))
     def test_gen_itp(args_in, ref_file):
         parser = argparse.ArgumentParser(


### PR DESCRIPTION
For now, I just added one more link to allow building of PEO-PE block copolymers, which seems to be necessary as explained in https://github.com/marrink-lab/polyply_1.0/issues/91.  More links, if needed, could be added as part of this pull request. 