### PR TITLE
Add DOIs to Martini 2 citations and fix typo in gen_itp.py

### DIFF
--- a/polyply/data/martini2_polymers/citations.bib
+++ b/polyply/data/martini2_polymers/citations.bib
@@ -6,7 +6,8 @@
   number={27},
   pages={7812--7824},
   year={2007},
-  publisher={ACS Publications}
+  publisher={ACS Publications},
+  doi={10.1021/jp071097f}
 }
 
 @article{PSS_M2,
@@ -17,7 +18,8 @@
   number={24},
   pages={243151},
   year={2015},
-  publisher={AIP Publishing LLC}
+  publisher={AIP Publishing LLC},
+  doi={10.1063/1.4937805}
 }
 
 @article{PEO_M2,
@@ -28,7 +30,8 @@
   number={29},
   pages={7436--7449},
   year={2018},
-  publisher={ACS Publications}
+  publisher={ACS Publications},
+  doi={10.1021/acs.jpcb.8b04760}
 }
 
 @article{PP_PE_M2,
@@ -39,7 +42,8 @@
   number={25},
   pages={8209--8216},
   year={2015},
-  publisher={ACS Publications}
+  publisher={ACS Publications},
+  doi={10.1021/acs.jpcb.5b03611}
 }
 
 @article{PS_M2,
@@ -50,7 +54,8 @@
   number={2},
   pages={698--708},
   year={2011},
-  publisher={Royal Society of Chemistry}
+  publisher={Royal Society of Chemistry},
+  doi={10.1039/C0SM00481B}
 }
 
 @article{P3HT_M2,
@@ -61,6 +66,7 @@
   number={10},
   pages={3697--3705},
   year={2017},
-  publisher={ACS Publications}
+  publisher={ACS Publications},
+  doi={10.1021/jacs.6b11717}
 }
 

--- a/polyply/src/gen_itp.py
+++ b/polyply/src/gen_itp.py
@@ -93,7 +93,7 @@ def gen_itp(args):
 
     with open(args.outpath, 'w') as outpath:
         header = [ ' '.join(sys.argv) + "\n" ]
-        header.append("Pleas cite the following papers:")
+        header.append("Please cite the following papers:")
         for citation in meta_molecule.molecule.citations:
             cite_string =  citation_formatter(meta_molecule.molecule.force_field.citations[citation])
             LOGGER.info("Please cite: " + cite_string)


### PR DESCRIPTION
I've added the DOIs to the bib entries - I think they make references more easy to find (and it works without problems!).

I also fixed a minor typo in `gen_itp.py`.

By the way, shall we get rid of the older headers, e.g, the following lines, now that citations are nicely taken care of?
https://github.com/marrink-lab/polyply_1.0/blob/2d21c2a6e777c4d2d41ccc5777bd3fb2b367667f/polyply/data/martini2_polymers/P3HT.martini.2.itp#L3-L16