### PR TITLE
Fix vermouth dependency error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install-requires =  # ?? requires-dist?
     numpy
     decorator == 4.4.2
     networkx ~= 2.0
-    vermouth >= 0.5.0
+    vermouth >= 0.7.1
     scipy
     tqdm
 zip-safe = False


### PR DESCRIPTION
The default vermouth version is too old. People that have installed an older version will get an error. 0.7.1 works fine for me.