### PR TITLE
Bug fix regarding the use of ligand annotator

### DIFF
--- a/polyply/src/gen_coords.py
+++ b/polyply/src/gen_coords.py
@@ -133,7 +133,8 @@ def gen_coords(args):
     LOGGER.info("generating templates",  type="step")
     GenerateTemplates(topology=topology, max_opt=10).run_system(topology)
     LOGGER.info("annotating ligands",  type="step")
-    AnnotateLigands(topology, args.ligands).run_system(topology)
+    ligand_annotator = AnnotateLigands(topology, args.ligands)
+    ligand_annotator.run_system(topology)
     LOGGER.info("generating system coordinates",  type="step")
     _initialize_cylces(topology, args.cycles, args.cycle_tol)
     BuildSystem(topology,
@@ -148,7 +149,7 @@ def gen_coords(args):
                 grid=args.grid,
                 cycles=args.cycles,
                 nrewind=args.nrewind).run_system(topology.molecules)
-    AnnotateLigands(topology, args.ligands).split_ligands()
+    ligand_annotator.split_ligands()
     LOGGER.info("backmapping to target resolution",  type="step")
     Backmap(fudge_coords=args.bfudge).run_system(topology)
     # Write output


### PR DESCRIPTION
This PR fixes a small logic bug in gen_coords regarding the ligand annotator. Instead of using the processor twice a new instance was generated when trying to split the ligands. That leads to incorrect behavior where the molecule is tagged twice with ligands. This blows up obviously. Tests for this fix are not within polyply but included in the new regression test suite, which will be subject to another PR.