### PR TITLE
relax restraint check; allow for branched molecules in principle

### DIFF
--- a/polyply/tests/test_restraints.py
+++ b/polyply/tests/test_restraints.py
@@ -64,6 +64,5 @@ def test_set_distance_restraint(test_molecule,
         ref_list = expected[node]
         for ref_restr, new_restr in zip(ref_list, restr_list):
             assert ref_restr[0] == new_restr[0]
-            assert pytest.approx(ref_restr[1], new_restr[1])
-            assert pytest.approx(ref_restr[2], new_restr[2])
-
+            assert np.isclose(ref_restr[1], new_restr[1], atol=0.001)
+            assert np.isclose(ref_restr[2], new_restr[2], atol=0.001)


### PR DESCRIPTION
Restraints for generally branched molecules turns out to be somewhat more involved than what is presented in the draft. Therefore this PR is an mid-way fix which relaxes the branching conditions a little and yields an error when the restraint cannot be satisfied due to branching. It's not optimal but needed for the publication. 