### PR TITLE
Solvation

### DIFF
--- a/bin/polyply
+++ b/bin/polyply
@@ -101,6 +101,8 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
     topology_group = parser_gen_coords.add_argument_group('Change or modify topology')
     topology_group.add_argument('-res', dest='build_res', type=str,
                                 help='list of residues to built', default=[], nargs='+')
+    topology_group.add_argument('-sol', dest='solvents', type=str,
+                                help='build these molecules as solvents', default=[], nargs='+')
     topology_group.add_argument('-ign', dest='ignore', type=str,
                                 help='molecules to ignore when building structure',
                                 default=[], nargs='+')

--- a/polyply/src/backmap.py
+++ b/polyply/src/backmap.py
@@ -155,9 +155,10 @@ class Backmap(Processor):
     for the lower resolution molecule associated with the MetaMolecule.
     """
 
-    def __init__(self, fudge_coords=0.4, *args, **kwargs):
+    def __init__(self, rescale_build=False, fudge_coords=0.4, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fudge_coords = fudge_coords
+        self.rescale_build = rescale_build
 
     def _place_init_coords(self, meta_molecule):
         """
@@ -188,6 +189,13 @@ class Backmap(Processor):
                     new_coords = cg_coord + vector * self.fudge_coords
                     meta_molecule.molecule.nodes[atom_high]["position"] = new_coords
                 built_nodes.append(resid)
+            else:
+                high_res_atoms = meta_molecule.nodes[node]["graph"].nodes
+                cg_coord = meta_molecule.nodes[node]["position"]
+                for atom_high  in high_res_atoms:
+                    old_coord = meta_molecule.molecule.nodes[atom_high]["position"]
+                    new_coord = old_coord - (cg_coord - old_coord) * self.fudge_coords
+                    meta_molecule.molecule.nodes[atom_high]["position"] = new_coord
 
     def run_molecule(self, meta_molecule):
         """

--- a/polyply/src/build_system.py
+++ b/polyply/src/build_system.py
@@ -227,16 +227,17 @@ class BuildSystem():
                 success, new_nonbond_matrix = self._handle_random_walk(molecule,
                                                                        mol_idx,
                                                                        vector_sphere)
+
+                if success:
+                    self.nonbond_matrix = new_nonbond_matrix
+                    self.nonbond_matrix.concatenate_trees()
+                    mol_idx += 1
+                    pbar.update(1)
+
             else:
                 success = False
-                # chache all solvent molecules
+                # cache all solvent molecules
                 self.solvents.append(mol_idx)
-                mol_idx += 1
-                pbar.update(1)
-
-            if success:
-                self.nonbond_matrix = new_nonbond_matrix
-                self.nonbond_matrix.concatenate_trees()
                 mol_idx += 1
                 pbar.update(1)
 

--- a/polyply/src/build_system.py
+++ b/polyply/src/build_system.py
@@ -241,6 +241,9 @@ class BuildSystem():
                 pbar.update(1)
 
         pbar.close()
+        # release the memory occupied by the box-grid
+        # we'll need to make a new grid
+        del self.box_grid
 
         LOGGER.info("Placing solvent molecules.")
         solvent_placer = Solvator(self.nonbond_matrix,

--- a/polyply/src/gen_coords.py
+++ b/polyply/src/gen_coords.py
@@ -149,6 +149,7 @@ def gen_coords(args):
                 ignore=args.ignore,
                 grid=args.grid,
                 cycles=args.cycles,
+                sol_mols=args.solvents,
                 nrewind=args.nrewind).run_system(topology.molecules)
     ligand_annotator.split_ligands()
     LOGGER.info("backmapping to target resolution",  type="step")

--- a/polyply/src/nonbond_engine.py
+++ b/polyply/src/nonbond_engine.py
@@ -134,6 +134,15 @@ class NonBondEngine():
                                                              boxsize=self.boxsize)]
         self.gndx_to_tree = {idx: 0 for idx in self.defined_idxs[0]}
 
+    def add_no_tree_pos(self, point, mol_idx, node_key, start=True):
+        """
+        Add `point` with global index `gndx` to the position-matrix
+        and but not a position tree. This is faster because the trees
+        are not rebuilt.
+        """
+        gndx = self.nodes_to_gndx[(mol_idx, node_key)]
+        self.positions[gndx] = point
+
     def add_positions(self, point, mol_idx, node_key, start=True):
         """
         Add `point` with global index `gndx` to the position-matrix

--- a/polyply/src/nonbond_engine.py
+++ b/polyply/src/nonbond_engine.py
@@ -284,16 +284,16 @@ class NonBondEngine():
 
             dist_mat = ref_tree.sparse_distance_matrix(pos_tree, self.cut_off)
 
-            if any(np.array(list(dist_mat.values())) < 0.1):
+            gndx = self.nodes_to_gndx[(mol_idx, node)]
+            if any(np.array(list(dist_mat.values())) < 0.1) and gndx not in defined_idxs:
                 return np.inf
 
-            gndx = self.nodes_to_gndx[(mol_idx, node)]
             current_atype = self.atypes[gndx]
 
             for pair, dist in dist_mat.items():
                 gndx_pair = defined_idxs[pair[1]]
 
-                if gndx_pair not in exclusions:
+                if gndx_pair not in exclusions and gndx != gndx_pair:
                     other_atype = self.atypes[gndx_pair]
                     params = self.interaction_matrix[frozenset([current_atype, other_atype])]
                     force += POTENTIAL_FUNC[potential](dist, point, self.positions[gndx_pair], params)

--- a/polyply/src/nonbond_engine.py
+++ b/polyply/src/nonbond_engine.py
@@ -53,7 +53,6 @@ lennard_jones_force = jit(_lennard_jones_force)
 
 POTENTIAL_FUNC = {"LJ": lennard_jones_force}
 
-
 def _n_particles(molecules):
     """
     Count the number of meta_molecule nodes

--- a/polyply/src/solvator.py
+++ b/polyply/src/solvator.py
@@ -22,11 +22,11 @@ from .processor import Processor
 from .nonbond_engine import POTENTIAL_FUNC
 from .random_walk import fulfill_geometrical_constraints
 
-def norm_lennard_jones_force(dist, sig, eps, force):
+def norm_lennard_jones_force(dist, sig, eps):
     """
     Norm of the LJ force between two particles.
     """
-    return np.abs(24 * eps / dist * ((2 * (sig/dist)**12.0) - (sig/dist)**6)) - force
+    return np.abs(24 * eps / dist * ((2 * (sig/dist)**12.0) - (sig/dist)**6))
 
 class Solvator(Processor):
     """
@@ -81,10 +81,11 @@ class Solvator(Processor):
                 max_sigma = sigma
         # compute the minimum distance these beads need to have in order
         # to fullfill the max-force criterion
-        min_dist = scipy.optimize.fsolve(norm_lennard_jones_force,
-                                         x0=0.2,
-                                         args=(max_sigma, 1.0, self.max_force))
-        print(min_dist)
+        def _min_ljn(dist):
+           return (norm_lennard_jones_force(dist sig=max_sigma, eps=1.0) - self.max_force)**2.0
+
+        min_dist = scipy.optimize.minimize_scalar(_min_ljn,
+                                                  x0=0.2,)
         # build grid
         grid = np.mgrid[0:self.box[0]:min_dist,
                         0:self.box[1]:min_dist,

--- a/polyply/src/solvator.py
+++ b/polyply/src/solvator.py
@@ -82,10 +82,11 @@ class Solvator(Processor):
         # compute the minimum distance these beads need to have in order
         # to fullfill the max-force criterion
         def _min_ljn(dist):
-           return (norm_lennard_jones_force(dist sig=max_sigma, eps=1.0) - self.max_force)**2.0
+            return (norm_lennard_jones_force(dist, sig=max_sigma, eps=1.0) - self.max_force)**2.0
 
-        min_dist = scipy.optimize.minimize_scalar(_min_ljn,
-                                                  x0=0.2,)
+        # at distances smaller than 0.1 non-bond forces are considered infinite
+        # and larger than 1.1 are beyond cut-off; hence the bounds of the search
+        min_dist = scipy.optimize.minimize_scalar(_min_ljn, method='bounded', bounds=(0.1, 1.1)).x
         # build grid
         grid = np.mgrid[0:self.box[0]:min_dist,
                         0:self.box[1]:min_dist,

--- a/polyply/src/solvator.py
+++ b/polyply/src/solvator.py
@@ -122,7 +122,7 @@ class Solvator(Processor):
                                                                 node=0)
                 node = molecules[self.mol_idxs[sol_idx]].nodes[0]
                 if fulfill_geometrical_constraints(point, node) and\
-                norm(force) < self.max_force:
+                   norm(force) < self.max_force:
 
                     not_placed_sols[sol_idx] = False
                     sol_coords[sol_idx][:] = point[:]

--- a/polyply/src/solvator.py
+++ b/polyply/src/solvator.py
@@ -1,0 +1,167 @@
+# Copyright 2020 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from numpy.random import default_rng
+from numpy.linalg import norm
+import scipy
+import scipy.optimize
+from tqdm import tqdm
+from .processor import Processor
+from .nonbond_engine import POTENTIAL_FUNC
+
+def norm_lennard_jones_force(dist, sig, eps, force):
+    """
+    Norm of the LJ force between two particles.
+    """
+    return 24 * eps / dist * ((2 * (sig/dist)**12.0) - (sig/dist)**6) - force
+
+class Solvator(Processor):
+    """
+    Generate coordinates for 1 residue
+    molecules that are often solvent
+    molecules.
+    """
+    def __init__(self,
+                 nonbond_matrix,
+                 max_force,
+                 mol_idxs,
+                 potential="LJ",
+                ):
+        """
+        Parameters
+        ----------
+        nonbond_matrix: :class:`polyply.src.nonbond_engine.NonBondMatrix`
+            the nonbonded forces and positions of the system
+        max_force: float
+            maximum allowed force on a particle in the one bead per residue
+            description
+        mol_idxs:
+            the indices of the solvent molecules to build
+        potential:
+            the form of the nonbonded potential
+        """
+        self.nonbond_matrix = nonbond_matrix
+        # concatenate all trees into one
+        self.nonbond_matrix.concatenate_trees()
+        # for convenience
+        self.box = self.nonbond_matrix.boxsize
+        self.max_force = max_force
+        self.mol_idxs = np.array(mol_idxs, dtype=int)
+        self.potential = potential
+
+    def clever_grid(self):
+        """
+        Given the largest sigma value of a collection of one bead per residue
+        description of solvents generate a grid that has as miniumum grid spacing
+        the distance at which the LJ force is at most the maximum force-criterion
+        provided. This also works for a mixed system of solvents and sizes, because
+        all cross interactions are geometric averages meaning they cannot exceed
+        the size of the self-interaction.
+        """
+        # find the largest self interaction sigma between two of the solvent beads
+        max_sigma = 0
+        for idx in self.mol_idxs:
+            gndx = self.nonbond_matrix.nodes_to_gndx[(idx, 0)]
+            atype_key = frozenset([self.nonbond_matrix.atypes[gndx]])
+            sigma = self.nonbond_matrix.interaction_matrix[atype_key][0]
+            if sigma > max_sigma:
+                max_sigma = sigma
+        # compute the minimum distance these beads need to have in order
+        # to fullfill the max-force criterion
+        min_dist = scipy.optimize.fsolve(norm_lennard_jones_force,
+                                         x0=0.2,
+                                         args=(max_sigma, 1.0, self.max_force))
+        # build grid
+        grid = np.mgrid[0:self.box[0]:min_dist,
+                        0:self.box[1]:min_dist,
+                        0:self.box[2]:min_dist].reshape(3, -1).T
+        return grid
+
+    def compute_forces(self, points):
+        """
+        Given an array of `points` compute the forces these points
+        have in relation to the coordinates saved in the nonbond
+        matrix.
+
+        Parameters
+        ----------
+        points: np.ndrarry
+            the points to compute the forces for
+
+        Returns
+        -------
+        forces: np.ndarray
+            an array of the force vectors corresponding to each point
+        """
+        #TODO
+        # move this implementation to the nonbond matrix
+        # probably should refactor the force computation then as well
+        # but that will take thorough performance checking
+        forces = np.zeros((points.shape[0]))
+        ref_tree = scipy.spatial.ckdtree.cKDTree(points,
+                                                 boxsize=self.box)
+
+        pos_tree = self.nonbond_matrix.position_trees[0]
+        dist_mat = ref_tree.sparse_distance_matrix(pos_tree, self.nonbond_matrix.cut_off)
+
+        for (sol_idx, gndx), dist in dist_mat.items():
+            sol_gndx = self.nonbond_matrix.nodes_to_gndx[(sol_idx, 0)]
+            atype_sol = self.nonbond_matrix.atypes[sol_gndx]
+            atype_ref = self.nonbond_matrix.atypes[gndx]
+            params = self.nonbond_matrix.interaction_matrix[frozenset([atype_sol, atype_ref])]
+            force_vect = POTENTIAL_FUNC[self.potential](dist,
+                                                        points[sol_idx],
+                                                        self.nonbond_matrix.positions[gndx],
+                                                        params)
+            norm_force = norm(force_vect)
+            forces[sol_idx] += norm_force
+        return forces
+
+    def run_system(self, molecules):
+        """
+        Add coordinates for solvent molecules to a system as
+        defined by the molecule indices (self.mol_idxs).
+        """
+        # the solvent molecules to be placed
+        not_placed_sols = np.full((self.mol_idxs.shape[0]), True)
+        sol_idxs = np.arange(0, self.mol_idxs.shape[0])
+        # initialize the grid
+        grid = self.clever_grid()
+        indices = np.arange(0, len(grid))
+        # a boolean mask recording which grid points are used
+        avail_indices = np.full((len(grid)), True)
+        # the progress bar
+        pbar = tqdm(total=not_placed_sols.shape[0])
+        while np.sum(not_placed_sols) > 0:
+            rng = default_rng()
+            selected_idx = rng.choice(indices[avail_indices],
+                                      size=not_placed_sols.sum(),
+                                      replace=False)
+
+            points = grid[selected_idx]
+            forces = self.compute_forces(points)
+            for sol_idx, point, force in zip(sol_idxs[not_placed_sols], points, forces):
+                if force < self.max_force:
+                    not_placed_sols[sol_idx] = False
+                    self.nonbond_matrix.add_positions(point,
+                                                      self.mol_idxs[sol_idx],
+                                                      node_key=0,
+                                                      start=True)
+                    pbar.update(1)
+
+            avail_indices[selected_idx] = False
+
+        pbar.close()
+        return molecules

--- a/polyply/src/solvator.py
+++ b/polyply/src/solvator.py
@@ -78,6 +78,7 @@ class Solvator(Processor):
             atype_key = frozenset([self.nonbond_matrix.atypes[gndx]])
             sigma = self.nonbond_matrix.interaction_matrix[atype_key][0]
             if sigma > max_sigma:
+                print(atype_key)
                 max_sigma = sigma
         # compute the minimum distance these beads need to have in order
         # to fullfill the max-force criterion
@@ -87,10 +88,12 @@ class Solvator(Processor):
         # at distances smaller than 0.1 non-bond forces are considered infinite
         # and larger than 1.1 are beyond cut-off; hence the bounds of the search
         min_dist = scipy.optimize.minimize_scalar(_min_ljn, method='bounded', bounds=(0.1, 1.1)).x
+        print(min_dist)
         # build grid
         grid = np.mgrid[0:self.box[0]:min_dist,
                         0:self.box[1]:min_dist,
                         0:self.box[2]:min_dist].reshape(3, -1).T
+        print(len(grid))
         return grid
 
     def run_system(self, molecules):
@@ -100,6 +103,7 @@ class Solvator(Processor):
         """
         # the solvent molecules to be placed
         not_placed_sols = np.full((self.mol_idxs.shape[0]), True)
+        print(np.sum(not_placed_sols))
         sol_idxs = np.arange(0, self.mol_idxs.shape[0])
         sol_coords = np.zeros((self.mol_idxs.shape[0], 3))
         # initialize the grid

--- a/polyply/tests/test_build_system.py
+++ b/polyply/tests/test_build_system.py
@@ -55,7 +55,7 @@ def example_topology():
     [ atoms ]
     1    N0  1   ASP    BB   1 0.00
     2    N0  1   ASP    SC1  1 0.00
-    3    N0  1   ASP    SC2  1 0.00
+    3    N0  2   GPN    BB   1 0.00
     [ bonds ]
     1    2    1  0.47 2000
     2    3    1  0.47 2000
@@ -71,7 +71,7 @@ def example_topology():
     topology = Topology(force_field)
     read_topology(lines=lines, topology=topology, cwdir="./")
     topology.preprocess()
-    topology.volumes = {"GLY": 0.53, "GLU": 0.67, "ASP": 0.43}
+    topology.volumes = {"GLY": 0.53, "GLU": 0.67, "ASP": 0.43, "GPN": 0.43}
     return topology
 
 @pytest.mark.parametrize('density, result', (
@@ -218,6 +218,7 @@ def test_build_system(positions,
                            start_dict=starting_nodes,
                            box=box,
                            grid=starting_grid,
+                           max_force=10**5
                            )
    processor.run_system(example_topology)
    total = 0

--- a/polyply/tests/test_nb_engine.py
+++ b/polyply/tests/test_nb_engine.py
@@ -192,8 +192,8 @@ def test_get_interaction(topology, mol_idx_a, mol_idx_b, node_a, node_b, expecte
 
 @pytest.mark.parametrize('dist, ref, expected',
                         # LJ force is zero at minimum
-			((2**(1/6.)*0.35,
-                          np.array([0.0, 0.0, 2**1/6.*0.35]),
+            			((2**(1/6.)*0.35,
+                          np.array([0.0, 0.0, 2**(1/6.)*0.35]),
                           np.array([0.0, 0.0, 0.0])),
                         # LJ force is also zero at infinity
                          (100000.0,
@@ -208,13 +208,14 @@ def test_get_interaction(topology, mol_idx_a, mol_idx_b, node_a, node_b, expecte
                           np.array([0.0, 0.42, 0.0]),
                           np.array([0.0, 13.27016, 0.0])),
                         # truly 3d distance
-                         (0.42,
+                         (0.48989794855663565,
                           np.array([0.2, 0.4, 0.2]),
-                          np.array([ 6.31912, 12.63825,  6.31912]))
+                          np.array([4.09965989, 8.19931978, 4.09965989]))
                         ))
 def test_LJ_force(dist, ref, expected):
      point = np.array([0.0, 0.0, 0.0])
      params = (0.35, 2.1)
+     # fail safe
+     assert dist == np.linalg.norm(ref)
      value = polyply.src.nonbond_engine._lennard_jones_force(dist, point, ref, params)
-     print(value)
      assert np.allclose(value, expected)

--- a/polyply/tests/test_solvator.py
+++ b/polyply/tests/test_solvator.py
@@ -134,10 +134,17 @@ def test_run_molecule(topology, mol_idxs, pos):
     assert all(solvent_placer.nonbond_matrix.positions[0] == np.array([0.0, 0.0, 0.0]))
     assert all(solvent_placer.nonbond_matrix.positions[1] == np.array([0.0, 0.0, 0.32]))
 
+    solvent_placer.nonbond_matrix.concatenate_trees()
+
     if pos is not None:
         for idx in range(0, pos.shape[0]):
             if all(pos[idx, :] != np.array([np.inf, np.inf, np.inf])):
-                assert all(solvent_placer.nonbond_matrix.positions[idx+2] == pos[idx, :])
+                internal_pos = solvent_placer.nonbond_matrix.positions[idx+2]
+                assert all(internal_pos == pos[idx, :])
+                force = solvent_placer.nonbond_matrix.compute_force_point(point=internal_pos,
+                                                                          mol_idx=idx+1,
+                                                                          node=0)
+                assert np.linalg.norm(force) < 10**5.
 
 @pytest.mark.parametrize('dist, expected',
                         # LJ force is zero at minimum

--- a/polyply/tests/test_solvator.py
+++ b/polyply/tests/test_solvator.py
@@ -158,5 +158,5 @@ def test_run_molecule(topology, mol_idxs, pos):
                         ))
 def test_LJ_force(dist, expected):
      ref = np.linalg.norm(expected)
-     value = polyply.src.solvator.norm_lennard_jones_force(dist, sig=0.35, eps=2.1, force=0)
+     value = polyply.src.solvator.norm_lennard_jones_force(dist, sig=0.35, eps=2.1)
      assert np.allclose(value, ref)

--- a/polyply/tests/test_solvator.py
+++ b/polyply/tests/test_solvator.py
@@ -1,0 +1,162 @@
+# Copyright 2020 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test that solvent molecules are placed correctly.
+"""
+import textwrap
+import pytest
+import numpy as np
+from vermouth.forcefield import ForceField
+import polyply
+from polyply.src.top_parser import read_topology
+from polyply.src.topology import Topology
+from polyply.src.nonbond_engine import NonBondEngine
+from polyply.src.solvator import Solvator
+
+@pytest.fixture
+def topology():
+    top_lines ="""
+    [ defaults ]
+    1   1   no   1.0     1.0
+    [ atomtypes ]
+    N0 45.0 0.000 A 0.0 0.0
+    [ nonbond_params ]
+    N0   N0   1 4.700000e-01    3.700000e+00
+    [ moleculetype ]
+    testA 1
+    [ atoms ]
+    1    N0  1   PEO    BB   1 0.00     45
+    2    N0  2   PEO    BB   1 0.00     45
+    [ bonds ]
+    1    2    1  0.47 2000
+    [ moleculetype ]
+    testB 1
+    [ atoms ]
+    1    N0  1   GLY    BB   1 0.00     45
+    2    N0  1   GLY    SC1  1 0.00     45
+    [ bonds ]
+    1    2    1  0.47 2000
+    [ moleculetype ]
+    testC 1
+    [ atoms ]
+    1    N0  1   ASP    BB   1 0.00
+    [ system ]
+    test system
+    [ molecules ]
+    testA 1
+    testB 4
+    testC 4
+    """
+    lines = textwrap.dedent(top_lines)
+    lines = lines.splitlines()
+    force_field = ForceField("test")
+    topology = Topology(force_field)
+    read_topology(lines=lines, topology=topology, cwdir="./")
+    topology.preprocess()
+    topology.volumes = {"ASP":0.2, "GLY": 0.4, "PEO": 0.4}
+    return topology
+
+@pytest.mark.parametrize('volumes, target_spacing', (
+    ({"ASP":0.2, "GLY": 0.4, "PEO": 0.4},
+     0.23802992,
+    ),
+    ({"ASP":0.6, "GLY": 0.4, "PEO": 0.4},
+    0.34618275,
+    ),))
+def test_clever_grid(topology, volumes, target_spacing):
+    topology.volumes = volumes
+    nb_engine = NonBondEngine.from_topology(topology.molecules,
+                                            topology,
+                                            box=np.array([4., 4., 4.]))
+    solvent_placer = Solvator(nb_engine,
+                              max_force=10**5,
+                              mol_idxs=[1,2,3,4,5,6,7,8])
+    current_grid = solvent_placer.clever_grid()
+    ref_grid = np.mgrid[0:4.0:target_spacing,
+                        0:4.0:target_spacing,
+                        0:4.0:target_spacing].reshape(3, -1).T
+    for idx in range(0, ref_grid.shape[0]):
+        assert np.allclose(ref_grid[idx], current_grid[idx])
+
+@pytest.mark.parametrize('mol_idxs, pos, ', (
+    # simple test; create all coordinates
+    ([1, 2, 3, 4, 5, 6, 7, 8],
+     None,
+    ),
+    # here we skip some already build solvents
+    ([3, 4, 5, 6, 7, 8],
+     np.array([[1.0, 1.0, 0.67],
+               [1.0, 1.0, 1.37]]),
+     ),
+    # here we need to skip one already defined position
+    ([2, 4, 5, 6, 7, 8],
+     np.array([[1.0, 1.0, 0.67],
+               [np.inf, np.inf, np.inf],
+               [1.0, 1.0, 1.30]]),
+    ),
+     ))
+def test_run_molecule(topology, mol_idxs, pos):
+    # add PEO positions
+    topology.molecules[0].nodes[0]["position"] = np.array([0.0, 0.0, 0.0])
+    topology.molecules[0].nodes[1]["position"] = np.array([0.0, 0.0, 0.32])
+
+    # add positions and labels of other molecules
+    if pos is not None:
+        for idx in range(0, pos.shape[0]):
+            topology.molecules[idx+1].nodes[0]["position"] = pos[idx, :]
+
+    # collect all top information in nonbond engine
+    nb_engine = NonBondEngine.from_topology(topology.molecules,
+                                            topology,
+                                            box=np.array([4., 4., 4.]))
+
+    solvent_placer = Solvator(nb_engine,
+                              max_force=10**5,
+                              mol_idxs=mol_idxs)
+    solvent_placer.run_system(topology.molecules)
+
+    # make sure all position are defined
+    for coord in solvent_placer.nonbond_matrix.positions:
+        assert all(coord != np.array([np.inf, np.inf, np.inf]))
+
+    # check that defined positions are presrved
+    assert all(solvent_placer.nonbond_matrix.positions[0] == np.array([0.0, 0.0, 0.0]))
+    assert all(solvent_placer.nonbond_matrix.positions[1] == np.array([0.0, 0.0, 0.32]))
+
+    if pos is not None:
+        for idx in range(0, pos.shape[0]):
+            if all(pos[idx, :] != np.array([np.inf, np.inf, np.inf])):
+                assert all(solvent_placer.nonbond_matrix.positions[idx+2] == pos[idx, :])
+
+@pytest.mark.parametrize('dist, expected',
+                        # LJ force is zero at minimum
+            			((2**(1/6.)*0.35,
+                          np.array([0.0, 0.0, 0.0])),
+                        # LJ force is also zero at infinity
+                         (100000.0,
+                          np.array([0.0, 0.0, 0.0])),
+                        # pick one point inbetween
+                         (0.42,
+                          np.array([0.0, 0.0, 13.27016])),
+                        # distance along different vector
+                         (0.42,
+                          np.array([0.0, 13.27016, 0.0])),
+                        # truly 3d distance
+                         (0.48989794855663565,
+                          np.array([4.09965989, 8.19931978, 4.09965989]))
+                        ))
+def test_LJ_force(dist, expected):
+     ref = np.linalg.norm(expected)
+     value = polyply.src.solvator.norm_lennard_jones_force(dist, sig=0.35, eps=2.1, force=0)
+     assert np.allclose(value, ref)


### PR DESCRIPTION
New processor to add one residue molecules, which are often solvents. It's based on a grid approach and is significantly faster and less memory intensive than adding these molecules through random-walk. I've tested adding up to 8 Mio solvent particles which takes about 20min. Placing solvent particles allows to specify geometrical restrictions. In a nutshell for all solvent molecules a grid is computed with a spacing such that the atom with the largest sigma when placed on a grid point does not induce a force larger than the max-force set. This means no overlap between solvents has to be computed and only overlap between solvent and already placed molecules is taken into account. 