### PR TITLE
Fix small typo (vinly --> vinyl); cosmetic

### DIFF
--- a/polyply/data/martini3/PMA.martini3.ff
+++ b/polyply/data/martini3/PMA.martini3.ff
@@ -13,12 +13,12 @@ PMA 1
 [ link ]
 resname "PMA"
 [ bonds ]
-VNL     +VNL    1     0.253 8000  {"group": "vinly backbone"}
+VNL     +VNL    1     0.253 8000  {"group": "vinyl backbone"}
 
 [ link ]
 resname "PMA"
 [ angles ]
-VNL  +VNL  ++VNL   2  139  100  {"group": "vinly backbone"}
+VNL  +VNL  ++VNL   2  139  100  {"group": "vinyl backbone"}
 
 [ link ]
 resname "PMA"

--- a/polyply/data/martini3/PMMA.martini3.ff
+++ b/polyply/data/martini3/PMMA.martini3.ff
@@ -13,12 +13,12 @@ PMMA 1
 [ link ]
 resname "PMMA"
 [ bonds ]
-VNL     +VNL    1     0.315 4000  {"group": "vinly backbone"}
+VNL     +VNL    1     0.315 4000  {"group": "vinyl backbone"}
 
 [ link ]
 resname "PMMA"
 [ angles ]
-VNL  +VNL  ++VNL   2  115  35  {"group": "vinly backbone"}
+VNL  +VNL  ++VNL   2  115  35  {"group": "vinyl backbone"}
 
 [ link ]
 resname "PMMA"


### PR DESCRIPTION
Unimportant, just cosmetic but I just noticed so I figured why not fix it.