### PR TITLE
Fix typo in warning about disjoint parts

### DIFF
--- a/polyply/src/gen_itp.py
+++ b/polyply/src/gen_itp.py
@@ -81,7 +81,7 @@ def gen_params(args):
     # Raise warning if molecule is disconnected
     if not nx.is_connected(meta_molecule.molecule):
         n_components = len(list(nx.connected_components(meta_molecule.molecule)))
-        msg = "You molecule consists of {:d} disjoint parts. Perhaps links were not applied correctly."
+        msg = "Your molecule consists of {:d} disjoint parts. Perhaps links were not applied correctly."
         LOGGER.warning(msg, (n_components))
 
     with deferred_open(args.outpath, 'w') as outpath:


### PR DESCRIPTION
Just noticed this typo - surprised I've never noticed before.!
