### PR TITLE
Raise more detailed warning about disconnected molecule

### DIFF
--- a/polyply/src/gen_itp.py
+++ b/polyply/src/gen_itp.py
@@ -58,6 +58,10 @@ def split_seq_string(sequence):
     return monomers
 
 def _are_connected(graph, origin_nodes, target_nodes):
+    """
+    Given a list of origin nodes check if any of these
+    nodes is neighbor to any of the target nodes.
+    """
     for node in origin_nodes:
         for neigh in graph.neighbors(node):
             if neigh in target_nodes:
@@ -68,6 +72,16 @@ def find_missing_links(meta_molecule):
     """
     Given a connected meta_molecule graph and a disconnected
     molecule, figure out which residue connections are missing.
+
+    Parameters
+    ----------
+    meta_molecule: `:class:polyply.MetaMolecule`
+
+    Yields:
+    --------
+    dict
+        dict containing the resnams and resids of the
+        nodes corresponding to the missing links
     """
     for origin, target in meta_molecule.edges:
         origin_nodes = meta_molecule.nodes[origin]['graph'].nodes
@@ -104,6 +118,8 @@ def gen_params(args):
 
     # Raise warning if molecule is disconnected
     if not nx.is_connected(meta_molecule.molecule):
+        LOGGER.warning("Your molecule consists of disjoint parts."
+                       "Perhaps links were not applied correctly.")
         msg = "Missing link between resiude {idxA} {resA} and residue {idxB} {resB}"
         for missing in find_missing_links(meta_molecule):
             LOGGER.warning(msg, **missing)

--- a/polyply/src/gen_itp.py
+++ b/polyply/src/gen_itp.py
@@ -124,7 +124,7 @@ def gen_params(args):
     if not nx.is_connected(meta_molecule.molecule):
         LOGGER.warning("Your molecule consists of disjoint parts."
                        "Perhaps links were not applied correctly.")
-        msg = "Missing link between resiude {idxA} {resA} and residue {idxB} {resB}"
+        msg = "Missing link between residue {idxA} {resA} and residue {idxB} {resB}"
         for missing in find_missing_links(meta_molecule):
             LOGGER.warning(msg, **missing)
 

--- a/polyply/src/gen_itp.py
+++ b/polyply/src/gen_itp.py
@@ -57,6 +57,10 @@ def split_seq_string(sequence):
         monomers.append(Monomer(resname=resname, n_blocks=n_blocks))
     return monomers
 
+# TODO move the two functions below to meta-molecule
+# and generalize to a function that returns edges
+# replacing the equivalent function in graph_utils
+
 def _are_connected(graph, origin_nodes, target_nodes):
     """
     Given a list of origin nodes check if any of these

--- a/polyply/src/graph_utils.py
+++ b/polyply/src/graph_utils.py
@@ -160,7 +160,7 @@ def find_missing_edges(res_graph, molecule):
     """
     for origin, target in res_graph.edges:
         connecting_edges = find_connecting_edges(res_graph, molecule, (origin, target))
-        if len(connecting_edges) == 0:
+        if not connecting_edges:
             resA = res_graph.nodes[origin]["resname"]
             resB = res_graph.nodes[target]["resname"]
             idxA = res_graph.nodes[origin]["resid"]

--- a/polyply/src/graph_utils.py
+++ b/polyply/src/graph_utils.py
@@ -137,6 +137,36 @@ def find_connecting_edges(res_graph, molecule, nodes):
 
     return edges
 
+def find_missing_edges(res_graph, molecule):
+    """
+    Given a molecular residue graph find all those nodes
+    that are connected in the residue graph but have no
+    connection in the molecule graph.
+
+    Parameters
+    ----------
+    res_graph: :class:`nx.Graph`
+        residue graph; must have the attribute "graph" and
+        "resid", where graph is the fragment the node describes
+        in the mol_graph
+    molecule: :class:`vermouth.molecule.Molecule`
+        vermouth molecule underlying the residue graph
+
+    Yields:
+    --------
+    dict
+        dict containing the resnams and resids of the
+        nodes corresponding to the missing links
+    """
+    for origin, target in res_graph.edges:
+        connecting_edges = find_connecting_edges(res_graph, molecule, (origin, target))
+        if len(connecting_edges) == 0:
+            resA = res_graph.nodes[origin]["resname"]
+            resB = res_graph.nodes[target]["resname"]
+            idxA = res_graph.nodes[origin]["resid"]
+            idxB = res_graph.nodes[target]["resid"]
+            yield {"resA": resA, "idxA": idxA, "resB": resB, "idxB": idxB}
+
 def _compute_path_length_cartesian(mol_idx, path, nonbond_matrix):
     """
     Computes the maximum length a graph path based on the super-CG model

--- a/polyply/src/meta_molecule.py
+++ b/polyply/src/meta_molecule.py
@@ -15,7 +15,7 @@ from collections import (namedtuple, OrderedDict)
 import networkx as nx
 from vermouth.graph_utils import make_residue_graph
 from vermouth.log_helpers import StyleAdapter, get_logger
-from .polyply_parser import read_polyply
+from vermouth.gmx.itp_read import read_itp
 from .graph_utils import find_nodes_with_attributes
 from .simple_seq_parsers import parse_txt, parse_ig, parse_fasta, parse_json
 
@@ -322,7 +322,9 @@ class MetaMolecule(nx.Graph):
         """
         with open(itp_file) as file_:
             lines = file_.readlines()
-            read_polyply(lines, force_field)
+            read_itp(lines, force_field)
+
+        _make_edges(force_field)
 
         graph = MetaMolecule._block_graph_to_res_graph(force_field.blocks[mol_name])
         meta_mol = cls(graph, force_field=force_field, mol_name=mol_name)

--- a/polyply/tests/test_gen_params.py
+++ b/polyply/tests/test_gen_params.py
@@ -124,8 +124,8 @@ def test_find_missing_links():
     meta_mol.molecule.remove_edge(15, 21) # resid 3,4
     missing = list(find_missing_edges(meta_mol, meta_mol.molecule))
     assert len(missing) == 2
-    for edge in missing:
+    for edge, ref in zip(missing, [(3, 4), (7, 8)]):
         assert edge["resA"] == "P3HTref"
         assert edge["resB"] == "P3HTref"
-        assert edge["idxA"] in [3, 4, 7, 8]
-        assert edge["idxB"] in [3, 4, 7, 8]
+        assert edge["idxA"] == ref[0]
+        assert edge["idxB"] == ref[1]

--- a/polyply/tests/test_gen_params.py
+++ b/polyply/tests/test_gen_params.py
@@ -21,7 +21,7 @@ import vermouth.forcefield
 import vermouth.molecule
 import vermouth.gmx.itp_read
 from polyply import gen_params, TEST_DATA, MetaMolecule
-from polyply.src.gen_itp import find_missing_links
+from polyply.src.graph_utils import find_missing_edges
 
 class TestGenParams():
     @staticmethod
@@ -122,7 +122,7 @@ def test_find_missing_links():
     meta_mol = MetaMolecule.from_itp(ff, fname, "P3HTref")
     meta_mol.molecule.remove_edge(39, 45) # resid 7,8
     meta_mol.molecule.remove_edge(15, 21) # resid 3,4
-    missing = list(find_missing_links(meta_mol))
+    missing = list(find_missing_edges(meta_mol, meta_mol.molecule))
     assert len(missing) == 2
     for edge in missing:
         assert edge["resA"] == "P3HTref"

--- a/polyply/tests/test_graph_utils.py
+++ b/polyply/tests/test_graph_utils.py
@@ -61,3 +61,15 @@ def test_find_connecting_edges(example_meta_molecule, nodes, expected):
                                                             example_meta_molecule.molecule,
                                                             nodes)
     assert result == expected
+
+
+@pytest.mark.parametrize('del_edge, expected',(
+                        ({"u":1, "v":4}, [{"resA": "A", "idxA": 1, "resB": "B", "idxB": 2}]),
+                        # central residue
+                        ({"u":6, "v":9}, [{"resA": "B", "idxA": 2, "resB": "A", "idxB": 3}]),
+                        ))
+def test_find_missing_edges(example_meta_molecule, del_edge, expected):
+    example_meta_molecule.molecule.remove_edge(**del_edge)
+    for idx, missing in enumerate(polyply.src.graph_utils.find_missing_edges(example_meta_molecule,
+                                                                             example_meta_molecule.molecule)):
+        assert missing == expected[idx]


### PR DESCRIPTION
For the polyply GUI implementation in MAD a more detailed warning about missing edges should be raised. This is a first draft for this. 