### PR TITLE
update links for abitrary ether vinyl combinations

### DIFF
--- a/polyply/data/2016H66/polyether_polyvinyl_links.ff
+++ b/polyply/data/2016H66/polyether_polyvinyl_links.ff
@@ -63,17 +63,57 @@ resname $PEO_VINYL_RES
 [ atoms ]
 VC1 { }
 VC2 { }
-SC3 { }
+SC1 { }
 +EC1 { }
 +O1 { }
 +EC2 { }
 [ angles ]
-SC3 VC1 +EC1 ga_15 {"comment":"CHn-CHn-C,CHn,OA,OE,NR,NT,NL", "group":"link"}
+SC1 VC2 +EC1 2 ga_15 {"comment":"CHn-CHn-C,CHn,OA,OE,NR,NT,NL", "group":"link"}
 [ pairs ]
-SC3 +O1 1 { "group": "link" }
+SC1 +O1 1 { "group": "link" }
 [ edges ]
 VC1 VC2
-VC2 SC3
+VC2 SC1
+VC2 +EC1
++EC1 +O1
++EC1 +EC2
+;
+[ link ]
+; side chain substiuent vinyl -> ether
+resname $PEO_VINYL_RES
+[ atoms ]
+VC1 { }
+VC2 { }
+SC1 { }
+SC2 { }
++EC1 { }
++O1 { }
++EC2 { }
+[ pairs ]
+SC2 +EC1 1 { "group": "link" }
+[ edges ]
+VC1 VC2
+VC2 SC1
+SC1 SC2
+VC2 +EC1
++EC1 +O1
++EC1 +EC2
+;
+[ link ]
+; side chain substiuent vinyl PMMA like -> ether
+resname $PEO_VINYL_RES
+[ atoms ]
+VC1 { }
+VC2 { }
+SB1 { }
++EC1 { }
++O1 { }
++EC2 { }
+[ pairs ]
+SB1 +O1 1 { "group": "link" }
+[ edges ]
+VC1 VC2
+VC2 SB1
 VC2 +EC1
 +EC1 +O1
 +EC1 +EC2
@@ -87,16 +127,35 @@ O1 { }
 EC2 { }
 +VC1 { }
 +VC2 { }
-+SC3 { }
++SC1 { }
 [ pairs ]
-EC2 +SC3 1 { "group": "link" }
+EC2 +SC1 1 { "group": "link" }
 [ edges ]
 EC1 O1
 O1 EC2
 EC2 +VC1
 +VC1 +VC2
-+VC2 +SC3
-
++VC2 +SC1
+;
+[ link ]
+; side PMMA like chain substiuent ether -> vinyl
+resname $PEO_VINYL_RES
+[ atoms ]
+EC1 { }
+O1 { }
+EC2 { }
++VC1 { }
++VC2 { }
++SB1 { }
+[ pairs ]
+O1 +SB1 1 { "group": "link" }
+[ edges ]
+EC1 O1
+O1 EC2
+EC2 +VC1
++VC1 +VC2
++VC2 +SB1
+;
 [ link ]
 resname $PEO_VINYL_RES
 ; vinyl -> vinyl -> ether

--- a/polyply/data/2016H66/polyvinyl_blocks.ff
+++ b/polyply/data/2016H66/polyvinyl_blocks.ff
@@ -286,7 +286,7 @@ PMAM 3
 5  N   1 PMAM SC3 5 -0.76 14.0067
 6  H   1 PMAM SC4 6  0.38 1.0080
 7  H   1 PMAM SC5 7  0.38 1.0080
-8  CH3 1 PMMA SB1 6  0.00 15.0350
+8  CH3 1 PMAM SB1 6  0.00 15.0350
 [ bonds ]
 1 2 2 gb_27 {"comment":"C,CHn-CHn,C"}
 2 3 2 gb_27 {"comment":"C,CHn-CHn,C"}
@@ -318,7 +318,6 @@ PMAM 3
 1 5 1
 2 6 1
 2 7 1
-5 7 1
 8 4 1
 8 5 1
 4 6 1 {"ifndef": "eq_polyply", "version": "1"}


### PR DESCRIPTION
some additional missing pair interactions, one incorrect pair when combining polyethers and polyvinyl in arbitrary combinations. Good thing is this should not have resulted into false simulations because these faulty conformations immediately crash. 

ToDo:

- [ ] check that all 1-4 pairs are present by running all combinations
- [x] build structures for each combinations and briefly run them
- [ ] check all angles and dihedrals are defined 