### PR TITLE
Small improv error message top_parser

### DIFF
--- a/polyply/src/top_parser.py
+++ b/polyply/src/top_parser.py
@@ -435,8 +435,9 @@ class TOPDirector(SectionLineParser):
 
         if not os.path.exists(filename):
             msg = ("Cannot find file {}. This can happen when you "
+                  "1) typed the path to the file wrongly or 2) when you "
                   "try to include force-field files from the GMX "
-                  "library (e.g. #incldue \"gromos\"). Instead provide "
+                  "library (e.g. #include \"gromos\"). Instead provide "
                   "the full path. Another source for this error can be "
                   "that you have a #ifdef section with an #include but "
                   "your include file does not exist. In that case if you "


### PR DESCRIPTION
Was getting this error:
```
OSError: Cannot find file /Users/riccardo/PD-UC/AA/polyply--reference/PH001_n30_opls_OK.itp. 
This can happen when you try to include force-field files from the GMX library (e.g. #incldue "gromos"). 
Instead provide the full path. Another source for this error can be that you have a #ifdef section 
with an #include but your include file does not exist. In that case if you don't have the file remove 
the #include statement.
```
and started to search for `#` statements and such... but it turned out that simply the path in my top was wrong (missing one subfolder...). So, I slightly edited the error message to put that - the simplest explanation for this error - as the first explanation. See if you like it.