### PR TITLE
[2] Fix/237

### DIFF
--- a/polyply/src/build_file_parser.py
+++ b/polyply/src/build_file_parser.py
@@ -38,7 +38,7 @@ class BuildDirector(SectionLineParser):
         self.rw_options = {}
         self.persistence_length = {}
         self.templates = {}
-        self.volumes = {}
+        self.topology.volumes = {}
 
     @SectionLineParser.section_parser('molecule')
     def _molecule(self, line, lineno=0):
@@ -160,7 +160,6 @@ class BuildDirector(SectionLineParser):
         nodeA = tokens[0]
         nodeB = tokens[1]
         self.templates[self.template_name].add_edge(nodeA, nodeB)
-        print("go here")
 
     @SectionLineParser.section_parser('volumes')
     def _volume(self, line, lineno=0):
@@ -169,7 +168,7 @@ class BuildDirector(SectionLineParser):
         directive and stores it.
         """
         resname, volume = line.split()
-        self.topology.volume[resname] = float(volume)
+        self.topology.volumes[resname] = float(volume)
 
     def finalize(self, lineno=0):
         """

--- a/polyply/src/generate_templates.py
+++ b/polyply/src/generate_templates.py
@@ -144,20 +144,22 @@ def _good_impropers(coords, block):
                 return False
     return True
 
-def compute_volume(molecule, block, coords, nonbond_params, treshold=1e-18):
+def compute_volume(block, coords, nonbond_params, treshold=1e-18):
     """
-    Given a `block`, which is part of `molecule` and
-    has the coordinates `coord` compute the radius
-    of gyration taking into account the volume of each
-    particle. The volume of a particle is considered to be
-    the sigma value of it's LJ self interaction parameter.
+    Given a `block`, which has the coordinates `coords`,
+    compute the radius of gyration taking into account
+    the volume of each particle. The volume of a particle
+    is considered to be the sigma value of it's LJ self-
+    interaction parameter.
 
     Parameters
     ----------
-    molecule:  :class:vermouth.molecule.Molecule
-    block:     :class:vermouth.molecule.Block
-    coords:    :class:dict
+    block:     :class:`vermouth.molecule.Block`
+    coords:    dict[abc.hashable]
         dictionary of positions in from node_idx: np.array
+    nonbond_params: dict[frozenset(abc.hashable, abc.hashable)]
+        dictionary of nonbonded parameters with atom-types as
+        keys and sigma, epsilon LJ parameters
     treshold: float
         distance from center of geometry at which the
         particle is not taken into account for the volume

--- a/polyply/src/generate_templates.py
+++ b/polyply/src/generate_templates.py
@@ -364,6 +364,6 @@ class GenerateTemplates(Processor):
         """
         if hasattr(meta_molecule, "templates"):
             self.templates.update(meta_molecule.templates)
-        self._gen_templates(meta_molecule)
+        self.gen_templates(meta_molecule)
         meta_molecule.templates = self.templates
         return meta_molecule

--- a/polyply/src/generate_templates.py
+++ b/polyply/src/generate_templates.py
@@ -179,10 +179,9 @@ def compute_volume(block, coords, nonbond_params, treshold=1e-18):
         atom_key = block.nodes[node]["atype"]
         rad = float(nonbond_params[frozenset([atom_key, atom_key])]["nb1"])
         diff = coord - res_center_of_geometry
-        if np.linalg.norm(diff) < treshold:
-            continue
-        geom_vects[idx, :] = diff + u_vect(diff) * rad
-        idx += 1
+        if np.linalg.norm(diff) > treshold:
+            geom_vects[idx, :] = diff + u_vect(diff) * rad
+            idx += 1
 
     if geom_vects.shape[0] > 1:
         radgyr = radius_of_gyration(geom_vects)

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -225,6 +225,7 @@ class Topology(System):
         self.mol_idx_by_name = defaultdict(list)
         self.persistences = []
         self.distance_restraints = defaultdict(dict)
+        self.volumes = {}
 
     def preprocess(self):
         """

--- a/polyply/tests/test_build_file_parser.py
+++ b/polyply/tests/test_build_file_parser.py
@@ -336,7 +336,7 @@ def test_template_parsing(test_system, line, names, edges, positions):
      """,
      {"PEO": 0.47, "P3HT": 0.61}),
 )))
-def test_template_parsing(test_system, line, expected):
+def test_volume_parsing(test_system, line, expected):
     lines = textwrap.dedent(line)
     lines = lines.splitlines()
     polyply.src.build_file_parser.read_build_file(lines,

--- a/polyply/tests/test_build_file_parser.py
+++ b/polyply/tests/test_build_file_parser.py
@@ -321,7 +321,7 @@ def test_template_parsing(test_system, line, names, edges, positions):
             assert edges[idx] == list(template.edges)
             for node_pos in positions[idx]:
                 node = node_pos[0]
-                assert all(np.array(node_pos[1:], dtype=float) == template.nodes[node]["position"])
+                assert np.all(np.array(node_pos[1:], dtype=float) == template.nodes[node]["position"])
 
 @pytest.mark.parametrize('line, expected', (
    (("""

--- a/polyply/tests/test_build_file_parser.py
+++ b/polyply/tests/test_build_file_parser.py
@@ -322,3 +322,24 @@ def test_template_parsing(test_system, line, names, edges, positions):
             for node_pos in positions[idx]:
                 node = node_pos[0]
                 assert all(np.array(node_pos[1:], dtype=float) == template.nodes[node]["position"])
+
+@pytest.mark.parametrize('line, expected', (
+   (("""
+     [ volumes ]
+     PEO 0.47
+     """,
+     {"PEO": 0.47}),
+    ("""
+     [ volumes ]
+     PEO 0.47
+     P3HT 0.61
+     """,
+     {"PEO": 0.47, "P3HT": 0.61}),
+)))
+def test_template_parsing(test_system, line, expected):
+    lines = textwrap.dedent(line)
+    lines = lines.splitlines()
+    polyply.src.build_file_parser.read_build_file(lines,
+                                                  test_system.molecules,
+                                                  test_system)
+    assert test_system.volumes == expected

--- a/polyply/tests/test_generate_templates.py
+++ b/polyply/tests/test_generate_templates.py
@@ -101,7 +101,7 @@ class TestGenTemps:
           polyply.src.polyply_parser.read_polyply(lines, ff)
           block = ff.blocks['GLY']
           coords = _expand_inital_coords(block)
-          vol = compute_volume(meta_mol, block, coords, nonbond_params)
+          vol = compute_volume(block, coords, nonbond_params)
           assert vol > 0.
 
       @staticmethod


### PR DESCRIPTION
Allows parsing and handling of volumes and residue templates. However, I don't like the mess of different processors setting hidden attributes. I think I'll get rid of the volumes and templates attribute of topology and meta-molecule and instead hand them down as processor arguments. 