### PR TITLE
make sure self-links are applied

### DIFF
--- a/polyply/src/apply_links.py
+++ b/polyply/src/apply_links.py
@@ -361,8 +361,7 @@ class ApplyLinks(Processor):
                 else:
                     new_interaction = interaction
 
-                interaction_key = tuple(new_interaction.atoms) +\
-                                  tuple([new_interaction.meta.get("version", 1)])
+                interaction_key = (*new_interaction.atoms, new_interaction.meta.get("version", 1))
                 self.applied_links[inter_type][interaction_key] = (new_interaction, citations)
 
     def apply_link_between_residues(self, meta_molecule, link, link_to_resid):

--- a/polyply/src/apply_links.py
+++ b/polyply/src/apply_links.py
@@ -342,7 +342,7 @@ class ApplyLinks(Processor):
         self.applied_links = defaultdict(dict)
         self.nodes_to_remove = []
 
-    def _update_applied_links(self, interactions_dict, molecule, citations, mapping=None):
+    def _update_interactions_dict(self, interactions_dict, molecule, citations, mapping=None):
         """
         Helper function for adding links to the applied links dictionary.
         If mapping is given the interaction atoms are mapped to the molecule
@@ -414,10 +414,10 @@ class ApplyLinks(Processor):
                 molecule.nodes[link_to_mol[node]].update(link.nodes[node].get('replace', {}))
 
         # based on the match we build the link interaction
-        self._update_applied_links(link.interactions,
-                                   molecule,
-                                   link.citations,
-                                   mapping=link_to_mol)
+        self._update_interactions_dict(link.interactions,
+                                       molecule,
+                                       link.citations,
+                                       mapping=link_to_mol)
 
         # now we already add the edges of this link
         # links can overwrite each other but the edges must be the same
@@ -447,7 +447,7 @@ class ApplyLinks(Processor):
         molecule = meta_molecule.molecule
         force_field = meta_molecule.force_field
         # we need to update the temporary interactions dict
-        self._update_applied_links(molecule.interactions, molecule, molecule.citations, mapping=None)
+        self._update_interactions_dict(molecule.interactions, molecule, molecule.citations, mapping=None)
         # now we can clear the molecule dict
         molecule.interactions = defaultdict(list)
 
@@ -490,8 +490,7 @@ class ApplyLinks(Processor):
             for atoms, (interaction, citation) in self.applied_links[inter_type].items():
                 if not any(atom in self.nodes_to_remove for atom in atoms):
                     meta_molecule.molecule.interactions[inter_type].append(interaction)
-                    if citation:
-                        meta_molecule.molecule.citations.update(citation)
+                    meta_molecule.molecule.citations.update(citation)
 
         for link in force_field.links:
             if link.molecule_meta.get('by_atom_id'):

--- a/polyply/src/apply_links.py
+++ b/polyply/src/apply_links.py
@@ -488,7 +488,7 @@ class ApplyLinks(Processor):
         # nodes
         for inter_type in self.applied_links:
             for atoms, (interaction, citation) in self.applied_links[inter_type].items():
-                if not any([atom in self.nodes_to_remove for atom in atoms]):
+                if not any(atom in self.nodes_to_remove for atom in atoms):
                     meta_molecule.molecule.interactions[inter_type].append(interaction)
                     if citation:
                         meta_molecule.molecule.citations.update(citation)

--- a/polyply/src/apply_links.py
+++ b/polyply/src/apply_links.py
@@ -409,7 +409,7 @@ class ApplyLinks(Processor):
         # replace any attributes from the link node section
         for node in link.nodes:
             # if the atomname is set to null we schedule the node to be removed
-            if "null" in link.nodes[node].get('replace', {}).get('atomname', {}):
+            if link.nodes[node].get('replace', {}).get('atomname', False) is None:
                 self.nodes_to_remove.append(link_to_mol[node])
             else:
                 molecule.nodes[link_to_mol[node]].update(link.nodes[node].get('replace', {}))
@@ -492,9 +492,9 @@ class ApplyLinks(Processor):
             if link.molecule_meta.get('by_atom_id'):
                 apply_explicit_link(molecule, link)
 
+        print(molecule.interactions)
         # take care to remove nodes if there are any scheduled for removal
-        for node in self.nodes_to_remove:
-            molecule.remove_nodes(node)
+        molecule.remove_nodes_from(self.nodes_to_remove)
 
         expand_excl(molecule)
         return meta_molecule

--- a/polyply/tests/test_apply_links.py
+++ b/polyply/tests/test_apply_links.py
@@ -341,6 +341,21 @@ def test_match_link_and_residue_atoms_fail(example_meta_molecule,
                          [[(0, 1, 2, 1)]],
                          [[(0, 0)]]
                         ),
+                        # 9 - test node get scheduled for removal
+                        ([[(0, {'name': 'BB'}),
+                           (1, {'name': 'BB1'}),
+                           (2, {'name': 'SC1'}),
+                           (3, {'name': 'SC2', 'replace': {'atomname': None}})]],
+                         [{0: 0, 1: 0, 2:0, 3:0}],
+                         ['angles'],
+                         [[vermouth.molecule.Interaction(atoms=(0, 1, 2),
+                                                        parameters=['1', '124', '500'],
+                                                        meta={})]],
+                         [[]],
+                         [[]],
+                         [[(0, 1, 2, 1)]],
+                         [[(0, 0)]]
+                        ),
                         ))
 def test_apply_link_to_residue(example_meta_molecule,
                                link_defs,
@@ -366,8 +381,14 @@ def test_apply_link_to_residue(example_meta_molecule,
         link.patterns = patterns
         link.make_edges_from_interaction_type(inter_type)
         processor.apply_link_between_residues(example_meta_molecule,
-                                                  link,
-                                                  link_to_resid)
+                                              link,
+                                              link_to_resid)
+
+    for node in processor.nodes_to_remove:
+        node_name = example_meta_molecule.molecule.nodes[node]['name']
+        for node in link.nodes:
+            if link.nodes[node]['name'] == node_name:
+                assert link.nodes[node]['replace']['atomname'] is None
 
     for nodes, inter_idxs, inter_type in zip(expected_nodes, expected_inters, inter_types):
         for inter_nodes, inter_idx in zip(nodes, inter_idxs):

--- a/polyply/tests/test_apply_links.py
+++ b/polyply/tests/test_apply_links.py
@@ -327,6 +327,20 @@ def test_match_link_and_residue_atoms_fail(example_meta_molecule,
                          [[(1, 4, 1)], [(6, 9, 1)], [(1, 4, 5, 6, 1)]],
                          [[(0, 0)], [(1, 0)], [(2, 0)]]
                         ),
+                        # 8 - simple check single residue but both nodes are the same
+                        ([[(0, {'name': 'BB'}),
+                           (1, {'name': 'BB1'}),
+                           (2, {'name': 'SC1'})]],
+                         [{0: 0, 1: 0, 2:0}],
+                         ['angles'],
+                         [[vermouth.molecule.Interaction(atoms=(0, 1, 2),
+                                                        parameters=['1', '124', '500'],
+                                                        meta={})]],
+                         [[]],
+                         [[]],
+                         [[(0, 1, 2, 1)]],
+                         [[(0, 0)]]
+                        ),
                         ))
 def test_apply_link_to_residue(example_meta_molecule,
                                link_defs,

--- a/polyply/tests/test_data/gen_params/input/removal.ff
+++ b/polyply/tests/test_data/gen_params/input/removal.ff
@@ -1,0 +1,36 @@
+; Copyright 2020 University of Groningen
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;    http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+[ moleculetype ]
+; name nexcl.
+PEO         1
+;
+[ atoms ]
+1  SN1a    1   PEO   EO  1   0.000  45
+2  SN2a    1   PEO   EP  1   0.000  45
+[ bonds ]
+1   2  1  0.44 7000
+
+[ link ]
+resname "PEO"
+[ bonds ]
+; back bone bonds
+EP   +EO   1   0.37  7000
+
+[ link ]
+resname "PEO"
+[ atoms ]
+EP {"replace": {"atomname": null}}
+[ non-edges]
+EP +EO

--- a/polyply/tests/test_data/gen_params/output/removal.itp
+++ b/polyply/tests/test_data/gen_params/output/removal.itp
@@ -1,0 +1,20 @@
+; /Users/fabian/ProgramDev/dev_env/bin/pytest test_gen_params.py
+
+; Please cite the following papers:
+
+[ moleculetype ]
+test 1
+
+[ atoms ]
+1 SN1a 1 PEO EO 1 0.0 45.0
+2 SN2a 1 PEO EP 1 0.0 45.0
+3 SN1a 2 PEO EO 2 0.0 45.0
+4 SN2a 2 PEO EP 2 0.0 45.0
+5 SN1a 3 PEO EO 3 0.0 45.0
+
+[ bonds ]
+1 2 1 0.44 7000
+3 4 1 0.44 7000
+2 3 1 0.37 7000
+4 5 1 0.37 7000
+

--- a/polyply/tests/test_data/gen_params/ref/removal.itp
+++ b/polyply/tests/test_data/gen_params/ref/removal.itp
@@ -1,0 +1,20 @@
+; /Users/fabian/ProgramDev/dev_env/bin/polyply gen_params -f ../input/test_removal.ff -seq PEO:3 -o removal.itp -name test -vv
+
+; Please cite the following papers:
+
+[ moleculetype ]
+testref 1
+
+[ atoms ]
+1 SN1a 1 PEO EO 1 0.0 45.0
+2 SN2a 1 PEO EP 1 0.0 45.0
+3 SN1a 2 PEO EO 2 0.0 45.0
+4 SN2a 2 PEO EP 2 0.0 45.0
+5 SN1a 3 PEO EO 3 0.0 45.0
+
+[ bonds ]
+1 2 1 0.44 7000
+3 4 1 0.44 7000
+2 3 1 0.37 7000
+4 5 1 0.37 7000
+

--- a/polyply/tests/test_gen_params.py
+++ b/polyply/tests/test_gen_params.py
@@ -56,7 +56,13 @@ class TestGenParams():
          "-seqf", TEST_DATA + "/gen_params/input/test_edge_attr.json",
          "-name", "test",
          "-o", TEST_DATA + "/gen_params/output/test_edge_attr_out.itp"],
-         TEST_DATA + "/gen_params/ref/test_edge_attr_ref.itp")
+         TEST_DATA + "/gen_params/ref/test_edge_attr_ref.itp"),
+        # check if nodes can be removed
+        (["-f", TEST_DATA+"/gen_params/input/removal.ff",
+         "-seq", "PEO:3",
+         "-name", "test",
+         "-o", TEST_DATA + "/gen_params/output/removal.itp"],
+         TEST_DATA + "/gen_params/ref/removal.itp")
         ))
     def test_gen_params(args_in, ref_file):
         parser = argparse.ArgumentParser(


### PR DESCRIPTION
In this PR we add molecule.interactions dict to the temporary dict in applied links. With that also interactions within a residue can be modified if need be. Also we add the option to remove nodes with the `'{'replace':'atomname': null}'` syntax as is the case for the vermouth applied links. 