### PR TITLE
Fix/coordreading

### DIFF
--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -388,8 +388,11 @@ class Topology(System):
         for meta_mol in self.molecules:
             for meta_node in meta_mol.nodes:
                 resname = meta_mol.nodes[meta_node]["resname"]
-                # the fragment graph nodes are not sorted
-                mol_nodes = sorted(meta_mol.nodes[meta_node]['graph'].nodes)
+                # the fragment graph nodes are not sorted so we sort them by index
+                # as defined in the itp-file to capture cases, where the molecule
+                # graph nodes are permuted with respect to the index
+                idx_nodes = nx.get_node_attributes(meta_mol.nodes[meta_node]['graph'], "index")
+                mol_nodes = [node for _, node in sorted(zip(idx_nodes.values(), idx_nodes.keys()))]
                 # skip residue if resname is to be skipped or
                 # if the no more coordinates are available
                 # in that case we want to build the node and

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -390,9 +390,9 @@ class Topology(System):
                 resname = meta_mol.nodes[meta_node]["resname"]
                 # the fragment graph nodes are not sorted so we sort them by index
                 # as defined in the itp-file to capture cases, where the molecule
-                # graph nodes are permuted with respect to the index
+                # graph nodes are permuted with respect to the index]
                 idx_nodes = nx.get_node_attributes(meta_mol.nodes[meta_node]['graph'], "index")
-                mol_nodes = sorted(meta_mol.nodes, key=idx_nodes.get)
+                mol_nodes = sorted(idx_nodes, key=idx_nodes.get)
                 # skip residue if resname is to be skipped or
                 # if the no more coordinates are available
                 # in that case we want to build the node and

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -392,7 +392,7 @@ class Topology(System):
                 # as defined in the itp-file to capture cases, where the molecule
                 # graph nodes are permuted with respect to the index
                 idx_nodes = nx.get_node_attributes(meta_mol.nodes[meta_node]['graph'], "index")
-                mol_nodes = [node for _, node in sorted(zip(idx_nodes.values(), idx_nodes.keys()))]
+                mol_nodes = sorted(meta_mol, key=idx_nodex.get)
                 # skip residue if resname is to be skipped or
                 # if the no more coordinates are available
                 # in that case we want to build the node and

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -392,7 +392,7 @@ class Topology(System):
                 # as defined in the itp-file to capture cases, where the molecule
                 # graph nodes are permuted with respect to the index
                 idx_nodes = nx.get_node_attributes(meta_mol.nodes[meta_node]['graph'], "index")
-                mol_nodes = sorted(meta_mol, key=idx_nodex.get)
+                mol_nodes = sorted(meta_mol, key=idx_nodes.get)
                 # skip residue if resname is to be skipped or
                 # if the no more coordinates are available
                 # in that case we want to build the node and

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -414,7 +414,6 @@ class Topology(System):
                         # based on a non-complete residue
                         try:
                             meta_mol.molecule.nodes[mol_node]["position"] = positions[total]
-                            print(mol_node, positions[total])
                         except IndexError:
                             resid = meta_mol.nodes[meta_node]['resid']
                             mol_name = meta_mol.mol_name

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -390,7 +390,7 @@ class Topology(System):
                 resname = meta_mol.nodes[meta_node]["resname"]
                 # the fragment graph nodes are not sorted so we sort them by index
                 # as defined in the itp-file to capture cases, where the molecule
-                # graph nodes are permuted with respect to the index]
+                # graph nodes are permuted with respect to the index
                 idx_nodes = nx.get_node_attributes(meta_mol.nodes[meta_node]['graph'], "index")
                 mol_nodes = sorted(idx_nodes, key=idx_nodes.get)
                 # skip residue if resname is to be skipped or

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -388,7 +388,8 @@ class Topology(System):
         for meta_mol in self.molecules:
             for meta_node in meta_mol.nodes:
                 resname = meta_mol.nodes[meta_node]["resname"]
-                mol_nodes = meta_mol.nodes[meta_node]['graph'].nodes
+                # the fragment graph nodes are not sorted
+                mol_nodes = sorted(meta_mol.nodes[meta_node]['graph'].nodes)
                 # skip residue if resname is to be skipped or
                 # if the no more coordinates are available
                 # in that case we want to build the node and
@@ -413,6 +414,7 @@ class Topology(System):
                         # based on a non-complete residue
                         try:
                             meta_mol.molecule.nodes[mol_node]["position"] = positions[total]
+                            print(mol_node, positions[total])
                         except IndexError:
                             resid = meta_mol.nodes[meta_node]['resid']
                             mol_name = meta_mol.mol_name

--- a/polyply/src/topology.py
+++ b/polyply/src/topology.py
@@ -392,7 +392,7 @@ class Topology(System):
                 # as defined in the itp-file to capture cases, where the molecule
                 # graph nodes are permuted with respect to the index
                 idx_nodes = nx.get_node_attributes(meta_mol.nodes[meta_node]['graph'], "index")
-                mol_nodes = sorted(meta_mol, key=idx_nodes.get)
+                mol_nodes = sorted(meta_mol.nodes, key=idx_nodes.get)
                 # skip residue if resname is to be skipped or
                 # if the no more coordinates are available
                 # in that case we want to build the node and

--- a/polyply/tests/test_topology.py
+++ b/polyply/tests/test_topology.py
@@ -18,9 +18,11 @@ Test that force field files are properly read.
 import textwrap
 import pytest
 import math
+import numpy as np
 import vermouth.forcefield
 import vermouth.molecule
 from vermouth.molecule import Interaction
+from vermouth.pdb.pdb import read_pdb
 import polyply.src.meta_molecule
 from polyply import TEST_DATA
 from polyply.src.topology import Topology
@@ -87,9 +89,12 @@ class TestTopology:
         """
         top = Topology.from_gmx_topfile(TEST_DATA + "/topology_test/pdb.top", "test")
         top.add_positions_from_file(TEST_DATA + "/topology_test/test.pdb")
-        for meta_mol in top.molecules:
+
+        pdb_mols = read_pdb(TEST_DATA + "/topology_test/test.pdb")
+        for idx, meta_mol in enumerate(top.molecules):
             for node in meta_mol.molecule.nodes:
-                assert "position" in meta_mol.molecule.nodes[node].keys()
+                ref_pos = pdb_mols[idx].nodes[node]['position']
+                assert np.all(ref_pos == meta_mol.molecule.nodes[node]['position'])
 
         for meta_mol in top.molecules:
             for node in meta_mol.nodes:


### PR DESCRIPTION
This resolves a bug where the molecule coordinates are permuted due to the residue graph being unsorted. 