### PR TITLE
Add PTMA CG M3 model to polyply library [arXiv:2209.02072]

### DIFF
--- a/polyply/data/martini3/PTMA.martini3.ff
+++ b/polyply/data/martini3/PTMA.martini3.ff
@@ -1,0 +1,60 @@
+[ moleculetype ]
+; name nexcl.
+PTMA     1
+ 
+[ atoms ]
+; id  type  resnr  residu atom  cgnr  charge  mass
+   1   SC3    1    PTMA   VNL    1     0.0     54
+   2   SN4a   1    PTMA   EST    2     0.0     54
+   3   SC3    1    PTMA    C1    3     0.0     54
+   4   SC3    1    PTMA    C2    4     0.0     54
+   5   SC3    1    PTMA    C3    5     0.0     54
+   6   TP5    1    PTMA    N4    6     0.0     36
+ 
+[ bonds ]
+; i  j   funct   length
+  1  2      1     0.262   15000 { "comment": "M3 PMMA model [10.1038/s41467-021-27627-4] shortened"}
+  2  3      1     0.253   15000 { "comment": "PMMA-TEMPO connection"} 
+  3  4      1     0.326   25000 { "comment": "cog (TEMPO)"}
+  3  5      1     0.326   25000 { "comment": "cog (TEMPO)"}
+  3  6      1     0.310  100000 {"ifdef": "FLEXIBLE", "comment": "cog (TEMPO)"} 
+  4  6      1     0.238  100000 {"ifdef": "FLEXIBLE", "comment": "cog (TEMPO)"}
+  5  6      1     0.238  100000 {"ifdef": "FLEXIBLE", "comment": "cog (TEMPO)"}
+ 
+[constraints]
+; i  j   funct   length
+  3  6      1     0.310  {"ifndef": "FLEXIBLE", "comment": "cog (TEMPO)"} 
+  4  6      1     0.238  {"ifndef": "FLEXIBLE", "comment": "cog (TEMPO)"}
+  5  6      1     0.238  {"ifndef": "FLEXIBLE", "comment": "cog (TEMPO)"}
+ 
+[ angles ]
+; i  j  k  funct   length  force k
+  1  2  3    2      132.9    70 { "comment": "PMMA-TEMPO connection"} 
+  2  3  4    2      129.0    60 { "comment": "PMMA-TEMPO connection"} 
+  2  3  5    2      121.9    95 { "comment": "PMMA-TEMPO connection"} 
+
+[dihedrals]
+; i j k l  funct  ref.angle   force_k
+  3 4 5 6    2      140.00      20 { "comment": "cog (TEMPO)"}
+  2 4 5 6    2      150.00      80 { "comment": "PMMA-TEMPO connection"}
+
+
+[ link ]
+resname "PTMA"
+[ bonds ]
+VNL     +VNL    1     0.315 4000  {"group": "vinyl backbone"}
+
+[ link ]
+resname "PTMA"
+[ angles ]
+VNL  +VNL  ++VNL   2  115  35  {"group": "vinyl backbone"}
+
+[ link ]
+resname "PTMA"
+[ angles ]
+EST  VNL  +VNL  2  70  20
+
+[ citation ]
+2022RAlessandri-arXiv
+Martini3
+polyply

--- a/polyply/data/martini3/citations.bib
+++ b/polyply/data/martini3/citations.bib
@@ -31,3 +31,14 @@ pages={382--388}
   publisher={The Royal Society of Chemistry},
   url={http://dx.doi.org/10.1039/D1CP04237H},
 }
+
+@article{2022RAlessandri-arXiv,
+  title={Predicting Electronic Properties of Radical-Containing Polymers at Coarse-Grained Resolutions},
+  author={Riccardo Alessandri and Juan J. de Pablo},
+  year={2022},
+  eprint={2209.02072},
+  archivePrefix={arXiv},
+  primaryClass={cond-mat.soft},
+  doi={https://doi.org/10.48550/arXiv.2209.02072} 
+}
+

--- a/polyply/data/martini3/citations.bib
+++ b/polyply/data/martini3/citations.bib
@@ -31,14 +31,12 @@ pages={382--388}
   publisher={The Royal Society of Chemistry},
   url={http://dx.doi.org/10.1039/D1CP04237H},
 }
-
 @article{2022RAlessandri-arXiv,
   title={Predicting Electronic Properties of Radical-Containing Polymers at Coarse-Grained Resolutions},
-  author={Riccardo Alessandri and Juan J. de Pablo},
+  author={Alessandri, Riccardo and de Pablo, Juan J.},
+  journal={arXiv},
   year={2022},
   eprint={2209.02072},
-  archivePrefix={arXiv},
   primaryClass={cond-mat.soft},
   doi={https://doi.org/10.48550/arXiv.2209.02072} 
 }
-

--- a/polyply/tests/test_data/library_tests/martini3/PTMA/polyply/PTMA.itp
+++ b/polyply/tests/test_data/library_tests/martini3/PTMA/polyply/PTMA.itp
@@ -1,0 +1,265 @@
+; /Users/alessandri/miniconda3/envs/polyply/bin/polyply gen_params -lib martini3 -seq PTMA:10 -o PTMA.itp -name PTMA
+
+; Please cite the following papers:
+; Alessandri, R; de Pablo, J J;  arXiv 2022; https://doi.org/10.48550/arXiv.2209.02072
+; Souza, P C T; Alessandri, R; Barnoud, J; Thallmair, S; Faustino, I; Grünewald, F; Patmanidis, I; Abdizadeh, H; Bruininks, B M H; Wassenaar, T A; Kroon, P C; Melcr, J; Nieto, V; Corradi, V; Khan, H M; Domański, J; Javanainen, M; Martinez-Seara, H; Reuter, N; Best, R B; Vattulainen, I; Monticelli, L; Periole, X; Tieleman, D P; de Vries, A H; Marrink, S J;  Nature Methods 2021; 10.1038/s41592-021-01098-3
+; Grunewald, F; Alessandri, R; Kroon, P C; Monticelli, L; Souza, P C; Marrink, S J;  Nature Communications 2022; 10.1038/s41467-021-27627-4
+
+[ moleculetype ]
+PTMA 1
+
+[ atoms ]
+ 1 SC3   1 PTMA VNL  1 0.0 54.0
+ 2 SN4a  1 PTMA EST  2 0.0 54.0
+ 3 SC3   1 PTMA C1   3 0.0 54.0
+ 4 SC3   1 PTMA C2   4 0.0 54.0
+ 5 SC3   1 PTMA C3   5 0.0 54.0
+ 6 TP5   1 PTMA N4   6 0.0 36.0
+ 7 SC3   2 PTMA VNL  7 0.0 54.0
+ 8 SN4a  2 PTMA EST  8 0.0 54.0
+ 9 SC3   2 PTMA C1   9 0.0 54.0
+10 SC3   2 PTMA C2  10 0.0 54.0
+11 SC3   2 PTMA C3  11 0.0 54.0
+12 TP5   2 PTMA N4  12 0.0 36.0
+13 SC3   3 PTMA VNL 13 0.0 54.0
+14 SN4a  3 PTMA EST 14 0.0 54.0
+15 SC3   3 PTMA C1  15 0.0 54.0
+16 SC3   3 PTMA C2  16 0.0 54.0
+17 SC3   3 PTMA C3  17 0.0 54.0
+18 TP5   3 PTMA N4  18 0.0 36.0
+19 SC3   4 PTMA VNL 19 0.0 54.0
+20 SN4a  4 PTMA EST 20 0.0 54.0
+21 SC3   4 PTMA C1  21 0.0 54.0
+22 SC3   4 PTMA C2  22 0.0 54.0
+23 SC3   4 PTMA C3  23 0.0 54.0
+24 TP5   4 PTMA N4  24 0.0 36.0
+25 SC3   5 PTMA VNL 25 0.0 54.0
+26 SN4a  5 PTMA EST 26 0.0 54.0
+27 SC3   5 PTMA C1  27 0.0 54.0
+28 SC3   5 PTMA C2  28 0.0 54.0
+29 SC3   5 PTMA C3  29 0.0 54.0
+30 TP5   5 PTMA N4  30 0.0 36.0
+31 SC3   6 PTMA VNL 31 0.0 54.0
+32 SN4a  6 PTMA EST 32 0.0 54.0
+33 SC3   6 PTMA C1  33 0.0 54.0
+34 SC3   6 PTMA C2  34 0.0 54.0
+35 SC3   6 PTMA C3  35 0.0 54.0
+36 TP5   6 PTMA N4  36 0.0 36.0
+37 SC3   7 PTMA VNL 37 0.0 54.0
+38 SN4a  7 PTMA EST 38 0.0 54.0
+39 SC3   7 PTMA C1  39 0.0 54.0
+40 SC3   7 PTMA C2  40 0.0 54.0
+41 SC3   7 PTMA C3  41 0.0 54.0
+42 TP5   7 PTMA N4  42 0.0 36.0
+43 SC3   8 PTMA VNL 43 0.0 54.0
+44 SN4a  8 PTMA EST 44 0.0 54.0
+45 SC3   8 PTMA C1  45 0.0 54.0
+46 SC3   8 PTMA C2  46 0.0 54.0
+47 SC3   8 PTMA C3  47 0.0 54.0
+48 TP5   8 PTMA N4  48 0.0 36.0
+49 SC3   9 PTMA VNL 49 0.0 54.0
+50 SN4a  9 PTMA EST 50 0.0 54.0
+51 SC3   9 PTMA C1  51 0.0 54.0
+52 SC3   9 PTMA C2  52 0.0 54.0
+53 SC3   9 PTMA C3  53 0.0 54.0
+54 TP5   9 PTMA N4  54 0.0 36.0
+55 SC3  10 PTMA VNL 55 0.0 54.0
+56 SN4a 10 PTMA EST 56 0.0 54.0
+57 SC3  10 PTMA C1  57 0.0 54.0
+58 SC3  10 PTMA C2  58 0.0 54.0
+59 SC3  10 PTMA C3  59 0.0 54.0
+60 TP5  10 PTMA N4  60 0.0 36.0
+
+[ bonds ]
+ 1  2 1 0.262 15000 ; M3 PMMA model [10.1038/s41467-021-27627-4] shortened
+ 2  3 1 0.253 15000 ; PMMA-TEMPO connection
+ 3  4 1 0.326 25000 ; cog (TEMPO)
+ 3  5 1 0.326 25000 ; cog (TEMPO)
+ 7  8 1 0.262 15000 ; M3 PMMA model [10.1038/s41467-021-27627-4] shortened
+ 8  9 1 0.253 15000 ; PMMA-TEMPO connection
+ 9 10 1 0.326 25000 ; cog (TEMPO)
+ 9 11 1 0.326 25000 ; cog (TEMPO)
+13 14 1 0.262 15000 ; M3 PMMA model [10.1038/s41467-021-27627-4] shortened
+14 15 1 0.253 15000 ; PMMA-TEMPO connection
+15 16 1 0.326 25000 ; cog (TEMPO)
+15 17 1 0.326 25000 ; cog (TEMPO)
+19 20 1 0.262 15000 ; M3 PMMA model [10.1038/s41467-021-27627-4] shortened
+20 21 1 0.253 15000 ; PMMA-TEMPO connection
+21 22 1 0.326 25000 ; cog (TEMPO)
+21 23 1 0.326 25000 ; cog (TEMPO)
+25 26 1 0.262 15000 ; M3 PMMA model [10.1038/s41467-021-27627-4] shortened
+26 27 1 0.253 15000 ; PMMA-TEMPO connection
+27 28 1 0.326 25000 ; cog (TEMPO)
+27 29 1 0.326 25000 ; cog (TEMPO)
+31 32 1 0.262 15000 ; M3 PMMA model [10.1038/s41467-021-27627-4] shortened
+32 33 1 0.253 15000 ; PMMA-TEMPO connection
+33 34 1 0.326 25000 ; cog (TEMPO)
+33 35 1 0.326 25000 ; cog (TEMPO)
+37 38 1 0.262 15000 ; M3 PMMA model [10.1038/s41467-021-27627-4] shortened
+38 39 1 0.253 15000 ; PMMA-TEMPO connection
+39 40 1 0.326 25000 ; cog (TEMPO)
+39 41 1 0.326 25000 ; cog (TEMPO)
+43 44 1 0.262 15000 ; M3 PMMA model [10.1038/s41467-021-27627-4] shortened
+44 45 1 0.253 15000 ; PMMA-TEMPO connection
+45 46 1 0.326 25000 ; cog (TEMPO)
+45 47 1 0.326 25000 ; cog (TEMPO)
+49 50 1 0.262 15000 ; M3 PMMA model [10.1038/s41467-021-27627-4] shortened
+50 51 1 0.253 15000 ; PMMA-TEMPO connection
+51 52 1 0.326 25000 ; cog (TEMPO)
+51 53 1 0.326 25000 ; cog (TEMPO)
+55 56 1 0.262 15000 ; M3 PMMA model [10.1038/s41467-021-27627-4] shortened
+56 57 1 0.253 15000 ; PMMA-TEMPO connection
+57 58 1 0.326 25000 ; cog (TEMPO)
+57 59 1 0.326 25000 ; cog (TEMPO)
+
+; vinyl backbone
+ 1  7 1 0.315 4000
+ 7 13 1 0.315 4000
+13 19 1 0.315 4000
+19 25 1 0.315 4000
+25 31 1 0.315 4000
+31 37 1 0.315 4000
+37 43 1 0.315 4000
+43 49 1 0.315 4000
+49 55 1 0.315 4000
+
+#ifdef FLEXIBLE
+ 3  6 1 0.310 100000 ; cog (TEMPO)
+ 4  6 1 0.238 100000 ; cog (TEMPO)
+ 5  6 1 0.238 100000 ; cog (TEMPO)
+ 9 12 1 0.310 100000 ; cog (TEMPO)
+10 12 1 0.238 100000 ; cog (TEMPO)
+11 12 1 0.238 100000 ; cog (TEMPO)
+15 18 1 0.310 100000 ; cog (TEMPO)
+16 18 1 0.238 100000 ; cog (TEMPO)
+17 18 1 0.238 100000 ; cog (TEMPO)
+21 24 1 0.310 100000 ; cog (TEMPO)
+22 24 1 0.238 100000 ; cog (TEMPO)
+23 24 1 0.238 100000 ; cog (TEMPO)
+27 30 1 0.310 100000 ; cog (TEMPO)
+28 30 1 0.238 100000 ; cog (TEMPO)
+29 30 1 0.238 100000 ; cog (TEMPO)
+33 36 1 0.310 100000 ; cog (TEMPO)
+34 36 1 0.238 100000 ; cog (TEMPO)
+35 36 1 0.238 100000 ; cog (TEMPO)
+39 42 1 0.310 100000 ; cog (TEMPO)
+40 42 1 0.238 100000 ; cog (TEMPO)
+41 42 1 0.238 100000 ; cog (TEMPO)
+45 48 1 0.310 100000 ; cog (TEMPO)
+46 48 1 0.238 100000 ; cog (TEMPO)
+47 48 1 0.238 100000 ; cog (TEMPO)
+51 54 1 0.310 100000 ; cog (TEMPO)
+52 54 1 0.238 100000 ; cog (TEMPO)
+53 54 1 0.238 100000 ; cog (TEMPO)
+57 60 1 0.310 100000 ; cog (TEMPO)
+58 60 1 0.238 100000 ; cog (TEMPO)
+59 60 1 0.238 100000 ; cog (TEMPO)
+#endif
+
+[ constraints ]
+#ifndef FLEXIBLE
+ 3  6 1 0.310 ; cog (TEMPO)
+ 4  6 1 0.238 ; cog (TEMPO)
+ 5  6 1 0.238 ; cog (TEMPO)
+ 9 12 1 0.310 ; cog (TEMPO)
+10 12 1 0.238 ; cog (TEMPO)
+11 12 1 0.238 ; cog (TEMPO)
+15 18 1 0.310 ; cog (TEMPO)
+16 18 1 0.238 ; cog (TEMPO)
+17 18 1 0.238 ; cog (TEMPO)
+21 24 1 0.310 ; cog (TEMPO)
+22 24 1 0.238 ; cog (TEMPO)
+23 24 1 0.238 ; cog (TEMPO)
+27 30 1 0.310 ; cog (TEMPO)
+28 30 1 0.238 ; cog (TEMPO)
+29 30 1 0.238 ; cog (TEMPO)
+33 36 1 0.310 ; cog (TEMPO)
+34 36 1 0.238 ; cog (TEMPO)
+35 36 1 0.238 ; cog (TEMPO)
+39 42 1 0.310 ; cog (TEMPO)
+40 42 1 0.238 ; cog (TEMPO)
+41 42 1 0.238 ; cog (TEMPO)
+45 48 1 0.310 ; cog (TEMPO)
+46 48 1 0.238 ; cog (TEMPO)
+47 48 1 0.238 ; cog (TEMPO)
+51 54 1 0.310 ; cog (TEMPO)
+52 54 1 0.238 ; cog (TEMPO)
+53 54 1 0.238 ; cog (TEMPO)
+57 60 1 0.310 ; cog (TEMPO)
+58 60 1 0.238 ; cog (TEMPO)
+59 60 1 0.238 ; cog (TEMPO)
+#endif
+
+[ angles ]
+ 1  2  3 2 132.9 70 ; PMMA-TEMPO connection
+ 2  3  4 2 129.0 60 ; PMMA-TEMPO connection
+ 2  3  5 2 121.9 95 ; PMMA-TEMPO connection
+ 7  8  9 2 132.9 70 ; PMMA-TEMPO connection
+ 8  9 10 2 129.0 60 ; PMMA-TEMPO connection
+ 8  9 11 2 121.9 95 ; PMMA-TEMPO connection
+13 14 15 2 132.9 70 ; PMMA-TEMPO connection
+14 15 16 2 129.0 60 ; PMMA-TEMPO connection
+14 15 17 2 121.9 95 ; PMMA-TEMPO connection
+19 20 21 2 132.9 70 ; PMMA-TEMPO connection
+20 21 22 2 129.0 60 ; PMMA-TEMPO connection
+20 21 23 2 121.9 95 ; PMMA-TEMPO connection
+25 26 27 2 132.9 70 ; PMMA-TEMPO connection
+26 27 28 2 129.0 60 ; PMMA-TEMPO connection
+26 27 29 2 121.9 95 ; PMMA-TEMPO connection
+31 32 33 2 132.9 70 ; PMMA-TEMPO connection
+32 33 34 2 129.0 60 ; PMMA-TEMPO connection
+32 33 35 2 121.9 95 ; PMMA-TEMPO connection
+37 38 39 2 132.9 70 ; PMMA-TEMPO connection
+38 39 40 2 129.0 60 ; PMMA-TEMPO connection
+38 39 41 2 121.9 95 ; PMMA-TEMPO connection
+43 44 45 2 132.9 70 ; PMMA-TEMPO connection
+44 45 46 2 129.0 60 ; PMMA-TEMPO connection
+44 45 47 2 121.9 95 ; PMMA-TEMPO connection
+49 50 51 2 132.9 70 ; PMMA-TEMPO connection
+50 51 52 2 129.0 60 ; PMMA-TEMPO connection
+50 51 53 2 121.9 95 ; PMMA-TEMPO connection
+55 56 57 2 132.9 70 ; PMMA-TEMPO connection
+56 57 58 2 129.0 60 ; PMMA-TEMPO connection
+56 57 59 2 121.9 95 ; PMMA-TEMPO connection
+ 2  1  7 2 70 20
+ 8  7 13 2 70 20
+14 13 19 2 70 20
+20 19 25 2 70 20
+26 25 31 2 70 20
+32 31 37 2 70 20
+38 37 43 2 70 20
+44 43 49 2 70 20
+50 49 55 2 70 20
+
+; vinyl backbone
+ 1  7 13 2 115 35
+ 7 13 19 2 115 35
+13 19 25 2 115 35
+19 25 31 2 115 35
+25 31 37 2 115 35
+31 37 43 2 115 35
+37 43 49 2 115 35
+43 49 55 2 115 35
+
+[ dihedrals ]
+ 3  4  5  6 2 140.00 20 ; cog (TEMPO)
+ 2  4  5  6 2 150.00 80 ; PMMA-TEMPO connection
+ 9 10 11 12 2 140.00 20 ; cog (TEMPO)
+ 8 10 11 12 2 150.00 80 ; PMMA-TEMPO connection
+15 16 17 18 2 140.00 20 ; cog (TEMPO)
+14 16 17 18 2 150.00 80 ; PMMA-TEMPO connection
+21 22 23 24 2 140.00 20 ; cog (TEMPO)
+20 22 23 24 2 150.00 80 ; PMMA-TEMPO connection
+27 28 29 30 2 140.00 20 ; cog (TEMPO)
+26 28 29 30 2 150.00 80 ; PMMA-TEMPO connection
+33 34 35 36 2 140.00 20 ; cog (TEMPO)
+32 34 35 36 2 150.00 80 ; PMMA-TEMPO connection
+39 40 41 42 2 140.00 20 ; cog (TEMPO)
+38 40 41 42 2 150.00 80 ; PMMA-TEMPO connection
+45 46 47 48 2 140.00 20 ; cog (TEMPO)
+44 46 47 48 2 150.00 80 ; PMMA-TEMPO connection
+51 52 53 54 2 140.00 20 ; cog (TEMPO)
+50 52 53 54 2 150.00 80 ; PMMA-TEMPO connection
+57 58 59 60 2 140.00 20 ; cog (TEMPO)
+56 58 59 60 2 150.00 80 ; PMMA-TEMPO connection
+

--- a/polyply/tests/test_data/library_tests/martini3/PTMA/polyply/command
+++ b/polyply/tests/test_data/library_tests/martini3/PTMA/polyply/command
@@ -1,0 +1,1 @@
+polyply gen_params -lib martini3 -seq PTMA:10 -o PTMA.itp -name PTMA

--- a/polyply/tests/test_lib_files.py
+++ b/polyply/tests/test_lib_files.py
@@ -185,6 +185,7 @@ def _interaction_equal(interaction1, interaction2, inter_type):
      ['martini3', 'DEX'],
      ['martini3', 'P3HT'],
      ['martini3', 'PPE'],
+     ['martini3', 'PTMA'],
      ['martini2', 'PEO'],
      ['martini2', 'PS'],
      ['martini2', 'PEL'],


### PR DESCRIPTION
Contributing the Martini 3 CG model developed for PTMA in https://arxiv.org/abs/2209.02072.

Test to follow.