### PR TITLE
Add PTMA CG IBI model to polyply library [arXiv:2209.02072]

### DIFF
--- a/polyply/data/ibi/PTMA.customexcl.ibi.ff
+++ b/polyply/data/ibi/PTMA.customexcl.ibi.ff
@@ -1,0 +1,65 @@
+[ moleculetype ]
+; name nexcl.
+PTMA     2
+ 
+[ atoms ]
+; id  type  resnr  residu atom  cgnr  charge  mass
+   1   VNL    1    PTMA   VNL    1     0.0     54
+   2   EST    1    PTMA   EST    2     0.0     54
+   3    C1    1    PTMA    C1    3     0.0     54
+   4    C2    1    PTMA    C2    4     0.0     54
+   5    C2    1    PTMA    C3    5     0.0     54
+   6    N4    1    PTMA    N4    6     0.0     36
+ 
+[ bonds ]
+; i  j   funct   length
+  1  2      1     0.262   15000 { "comment": "M3 PMMA model [10.1038/s41467-021-27627-4] shortened"}
+  2  3      1     0.253   15000 { "comment": "PMMA-TEMPO connection"} 
+  3  4      1     0.326   25000 { "comment": "cog (TEMPO)"}
+  3  5      1     0.326   25000 { "comment": "cog (TEMPO)"}
+  3  6      1     0.310  100000 {"ifdef": "FLEXIBLE", "comment": "cog (TEMPO)"} 
+  4  6      1     0.238  100000 {"ifdef": "FLEXIBLE", "comment": "cog (TEMPO)"}
+  5  6      1     0.238  100000 {"ifdef": "FLEXIBLE", "comment": "cog (TEMPO)"}
+ 
+[constraints]
+; i  j   funct   length
+  3  6      1     0.310  {"ifndef": "FLEXIBLE", "comment": "cog (TEMPO)"} 
+  4  6      1     0.238  {"ifndef": "FLEXIBLE", "comment": "cog (TEMPO)"}
+  5  6      1     0.238  {"ifndef": "FLEXIBLE", "comment": "cog (TEMPO)"}
+ 
+[ angles ]
+; i  j  k  funct   length  force k
+  1  2  3    2      132.9    70 { "comment": "PMMA-TEMPO connection"} 
+  2  3  4    2      129.0    60 { "comment": "PMMA-TEMPO connection"} 
+  2  3  5    2      121.9    95 { "comment": "PMMA-TEMPO connection"} 
+
+[dihedrals]
+; i j k l  funct  ref.angle   force_k
+  3 4 5 6    2      140.00      20 { "comment": "cog (TEMPO)"}
+  2 4 5 6    2      150.00      80 { "comment": "PMMA-TEMPO connection"}
+
+[exclusions]
+  1 2 3 4 5 6
+  2 3 4 5 6 
+  3 4 5 6  
+  4 5 6  
+  5 6
+
+[ link ]
+resname "PTMA"
+[ bonds ]
+VNL     +VNL    1     0.315 4000  {"group": "vinyl backbone"}
+
+[ link ]
+resname "PTMA"
+[ angles ]
+VNL  +VNL  ++VNL   2  115  35  {"group": "vinyl backbone"}
+
+[ link ]
+resname "PTMA"
+[ angles ]
+EST  VNL  +VNL  2  70  20
+
+[ citation ]
+2022RAlessandri-arXiv
+polyply

--- a/polyply/data/ibi/citations.bib
+++ b/polyply/data/ibi/citations.bib
@@ -1,0 +1,19 @@
+@article{2022RAlessandri-arXiv,
+  title={Predicting Electronic Properties of Radical-Containing Polymers at Coarse-Grained Resolutions},
+  author={Alessandri, Riccardo and de Pablo, Juan J.},
+  journal={arXiv},
+  year={2022},
+  eprint={2209.02072},
+  primaryClass={cond-mat.soft},
+  doi={https://doi.org/10.48550/arXiv.2209.02072} 
+}
+
+@article{polyply,
+  title={Polyply; a python suite for facilitating simulations of (bio-) macromolecules and nanomaterials},
+  author={Grunewald, Fabian and Alessandri, Riccardo and Kroon, Peter C and Monticelli, Luca and Souza, Paulo CT and Marrink, Siewert J},
+  journal={Nature Communications},
+  doi={10.1038/s41467-021-27627-4},
+  year={2022},
+  volume={13},
+  pages={68}
+}


### PR DESCRIPTION
Contributing the Iterative Boltzmann Inversion (IBI) CG model (that uses the same mapping as the [Martini 3 model](0870f5cc954e9a9fcbc37f8e2d948900588caefb), a mapping dubbed "CGM3") developed for PTMA in https://arxiv.org/abs/2209.02072.

Test to follow, but first we need to figure out Discussion https://github.com/marrink-lab/polyply_1.0/discussions/278.