### PR TITLE
Add a library table, i.e., list of models available in the polyply library

### DIFF
--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -1,7 +1,7 @@
 
-| polymer | All-Atom                                                                | Coarse-Grained                                       |
-|---------|-------------------------------------------------------------------------|------------------------------------------------------|
-| PEO     | [gromos2016H66](polyply/data/2016H66/polyether_blocks.ff)               | [Martini 2](polyply/data/martini2/PEO.martini.2.itp) |
-|         | [oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEO.oplsaa.LigParGen.ff) | [Martini 3](polyply/data/martini2/PEO.martini3.ff)   |
-| P3HT    | [gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)               | [Martini 2](polyply/data/martini2/P3HT.martini.2.itp)|
-|         |                                                                         | [Martini 3](polyply/data/martini2/P3HT.martini3.ff)  |
+| Polymer name           | Abbreviation | All-atom model(s)                                                       | Coarse-grained model(s)                              |
+|------------------------|--------------|-------------------------------------------------------------------------|------------------------------------------------------|
+| Polyethylene oxide     | PEO          | [gromos2016H66](polyply/data/2016H66/polyether_blocks.ff)               | [Martini 2](polyply/data/martini2/PEO.martini.2.itp) |
+|                        |              | [oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEO.oplsaa.LigParGen.ff) | [Martini 3](polyply/data/martini2/PEO.martini3.ff)   |
+| Poly(3-hexylthiophene) | P3HT         | [gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)               | [Martini 2](polyply/data/martini2/P3HT.martini.2.itp)|
+|                        |              |                                                                         | [Martini 3](polyply/data/martini2/P3HT.martini3.ff)  |

--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -1,0 +1,7 @@
+
+| polymer | All-Atom                                                                | Coarse-Grained                                       |
+|---------|-------------------------------------------------------------------------|------------------------------------------------------|
+| PEO     | [gromos2016H66](polyply/data/2016H66/polyether_blocks.ff)               | [Martini 2](polyply/data/martini2/PEO.martini.2.itp) |
+|         | [oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEO.oplsaa.LigParGen.ff) | [Martini 3](polyply/data/martini2/PEO.martini3.ff)   |
+| P3HT    | [gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)               | [Martini 2](polyply/data/martini2/P3HT.martini.2.itp)|
+|         |                                                                         | [Martini 3](polyply/data/martini2/P3HT.martini3.ff)  |

--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -14,6 +14,9 @@
 |Poly(3-hexylthiophene)         |P3HT                     |[gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)              |[martini2](polyply/data/martini2/P3HT.martini.2.itp)  |
 |                               |                         |                                                                       |[martini3](polyply/data/martini3/P3HT.martini3.ff)    |
 |Polyvinyl alcohol              |PVA                      |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |[martini3](polyply/data/martini3/PVA.martini3.ff)     |
+|Poly(2-hydroxyethyl acrylate)  |HEA                      |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |                                                      |
+|Polyacrylamide                 |PAM                      |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |                                                      |
+|Poly(methacrylamide)           |PMAM                     |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |                                                      |
 |Poly(diallyldimethylammonium)  |PDADMA                   |                                                                       |[martini2](polyply/data/martini2/PDADMA.martini.2.itp)|
 |Polystyrene sulfonate          |PSS                      |                                                                       |[martini2](polyply/data/martini2/PSS.martini.2.itp)   |
 |                               |                         |                                                                       |[martini3](polyply/data/martini3/PSS.martini3.ff)     |

--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -21,8 +21,8 @@
 |Polystyrene sulfonate          |PSS                      |                                                                       |[martini2](polyply/data/martini2/PSS.martini.2.itp)   |
 |                               |                         |                                                                       |[martini3](polyply/data/martini3/PSS.martini3.ff)     |
 |Poly(para-phenylene ethynylene)|PPE                      |                                                                       |[martini3](polyply/data/martini3/PPE.martini3.ff)     |
-|Poly(TEMPO methacrylate)       |PTMA                     |                                                                       |[martini3](polyply/data/martini3/PPE.martini3.ff)     |
-|Dextran                        |DEX                      |                                                                       |[martini3](polyply/data/martini3/PTMA.martini3.ff)    |
+|Poly(TEMPO methacrylate)       |PTMA                     |                                                                       |[martini3](polyply/data/martini3/PTMA.martini3.ff)    |
+|Dextran                        |DEX                      |                                                                       |[martini3](polyply/data/martini3/dextran.martini3.ff) |
 |DNA nucleobases                |Dx, Tx5, Dx3 w/ x=T,G,A,C|[parmbsc1](polyply/data/parmbsc1/dna_final.ff)                         |[martini2](polyply/data/martini2/DNA_M2.ff)           |
 |Aminoacids                     |3 letter code            |                                                                       |[martini3](polyply/data/martini3/aminoacids.ff)       |
 

--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -1,17 +1,21 @@
 
-| Polymer name           | Abbreviation                | All-atom model(s)                                                       | Coarse-grained model(s)                              |
-|------------------------|-----------------------------|-------------------------------------------------------------------------|------------------------------------------------------|
-| Polyethylene oxide     | PEO                         | [gromos2016H66](polyply/data/2016H66/polyether_blocks.ff)               | [martini2](polyply/data/martini2/PEO.martini.2.itp)  |
-|                        |                             | [oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEO.oplsaa.LigParGen.ff) | [martini3](polyply/data/martini3/PEO.martini3.ff)    |
-| Polystyrene            | PS                          | [gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               | [martini2](polyply/data/martini2/PS.martini.2.itp)   |
-|                        |                             |                                                                         | [martini3](polyply/data/martini3/PS.martini3.ff)     |
-| Polymethyl acrylate    | PMA                         | [gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               | [martini3](polyply/data/martini3/PMA.martini3.ff)    |
-| Polymethyl methacrylate| PMMA                        | [gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               | [martini3](polyply/data/martini3/PMMA.martini3.ff)   |
-| Polyethylene           | PE                          | [gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               | [martini3](polyply/data/martini3/PE.martini3.ff)     |
-| Poly(3-hexylthiophene) | P3HT                        | [gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)               | [martini2](polyply/data/martini2/P3HT.martini.2.itp) |
-|                        |                             |                                                                         | [martini3](polyply/data/martini3/P3HT.martini3.ff)   |
-| Polyvinyl alcohol      | PVA                         | [gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               | [martini3](polyply/data/martini3/PVA.martini3.ff)    |
-| Dextran                | DEX                         |                                                                         | [martini3](polyply/data/martini3/dextran.martini3.ff)|
-| DNA nucleobases        | Dx, Tx5, Dx3 with x=T,G,A,C | [parmbsc1](polyply/data/parmbsc1/dna_final.ff)                          |                                                      |
-| Aminoacids             | 3 letter code               |                                                                         | [martini3](polyply/data/martini3/aminoacids.ff)      |
+| Polymer name                | Abbreviation             | All-atom model(s)                                                      | Coarse-grained model(s)                              |
+|-----------------------------|--------------------------|------------------------------------------------------------------------|------------------------------------------------------|
+|Polyethylene oxide           |PEO                       |[gromos2016H66](polyply/data/2016H66/polyether_blocks.ff)               |[martini2](polyply/data/martini2/PEO.martini.2.itp)   |
+|                             |                          |[oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEO.oplsaa.LigParGen.ff) |[martini3](polyply/data/martini3/PEO.martini3.ff)     |
+|Polystyrene                  |PS                        |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               |[martini2](polyply/data/martini2/PS.martini.2.itp)    |
+|                             |                          |                                                                        |[martini3](polyply/data/martini3/PS.martini3.ff)      |
+|Polymethyl acrylate          |PMA                       |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               |[martini3](polyply/data/martini3/PMA.martini3.ff)     |
+|Polymethyl methacrylate      |PMMA                      |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               |[martini3](polyply/data/martini3/PMMA.martini3.ff)    |
+|Polyethylene                 |PE                        |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               |[martini3](polyply/data/martini3/PE.martini3.ff)      |
+|                             |                          |                                                                        |[martini2](polyply/data/martini2/PE.martini.2.itp)    |
+|Polypropylene                |PP                        |                                                                        |[martini2](polyply/data/martini2/PP.martini.2.itp)    |
+|Poly(3-hexylthiophene)       |P3HT                      |[gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)               |[martini2](polyply/data/martini2/P3HT.martini.2.itp)  |
+|                             |                          |                                                                        |[martini3](polyply/data/martini3/P3HT.martini3.ff)    |
+|Polyvinyl alcohol            |PVA                       |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               |[martini3](polyply/data/martini3/PVA.martini3.ff)     |
+|Poly(diallyldimethylammonium)|PDADMA                    |                                                                        |[martini2](polyply/data/martini2/PDADMA.martini.2.itp)|
+|Polystyrene sulfonate        |PSS                       |                                                                        |[martini2](polyply/data/martini2/PSS.martini.2.itp)   |
+|Dextran                      |DEX                       |                                                                        |[martini3](polyply/data/martini3/dextran.martini3.ff) |
+|DNA nucleobases              |Dx, Tx5, Dx3 w/ x=T,G,A,C |[parmbsc1](polyply/data/parmbsc1/dna_final.ff)                          |[martini2](polyply/data/martini2/DNA_M2.ff)           |
+|Aminoacids                   |3 letter code             |                                                                        |[martini3](polyply/data/martini3/aminoacids.ff)       |
 

--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -1,21 +1,25 @@
 
-| Polymer name                | Abbreviation             | All-atom model(s)                                                      | Coarse-grained model(s)                              |
-|-----------------------------|--------------------------|------------------------------------------------------------------------|------------------------------------------------------|
-|Polyethylene oxide           |PEO                       |[gromos2016H66](polyply/data/2016H66/polyether_blocks.ff)               |[martini2](polyply/data/martini2/PEO.martini.2.itp)   |
-|                             |                          |[oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEO.oplsaa.LigParGen.ff) |[martini3](polyply/data/martini3/PEO.martini3.ff)     |
-|Polystyrene                  |PS                        |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               |[martini2](polyply/data/martini2/PS.martini.2.itp)    |
-|                             |                          |                                                                        |[martini3](polyply/data/martini3/PS.martini3.ff)      |
-|Polymethyl acrylate          |PMA                       |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               |[martini3](polyply/data/martini3/PMA.martini3.ff)     |
-|Polymethyl methacrylate      |PMMA                      |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               |[martini3](polyply/data/martini3/PMMA.martini3.ff)    |
-|Polyethylene                 |PE                        |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               |[martini3](polyply/data/martini3/PE.martini3.ff)      |
-|                             |                          |                                                                        |[martini2](polyply/data/martini2/PE.martini.2.itp)    |
-|Polypropylene                |PP                        |                                                                        |[martini2](polyply/data/martini2/PP.martini.2.itp)    |
-|Poly(3-hexylthiophene)       |P3HT                      |[gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)               |[martini2](polyply/data/martini2/P3HT.martini.2.itp)  |
-|                             |                          |                                                                        |[martini3](polyply/data/martini3/P3HT.martini3.ff)    |
-|Polyvinyl alcohol            |PVA                       |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               |[martini3](polyply/data/martini3/PVA.martini3.ff)     |
-|Poly(diallyldimethylammonium)|PDADMA                    |                                                                        |[martini2](polyply/data/martini2/PDADMA.martini.2.itp)|
-|Polystyrene sulfonate        |PSS                       |                                                                        |[martini2](polyply/data/martini2/PSS.martini.2.itp)   |
-|Dextran                      |DEX                       |                                                                        |[martini3](polyply/data/martini3/dextran.martini3.ff) |
-|DNA nucleobases              |Dx, Tx5, Dx3 w/ x=T,G,A,C |[parmbsc1](polyply/data/parmbsc1/dna_final.ff)                          |[martini2](polyply/data/martini2/DNA_M2.ff)           |
-|Aminoacids                   |3 letter code             |                                                                        |[martini3](polyply/data/martini3/aminoacids.ff)       |
+| Polymer name                  | Abbreviation            | All-atom model(s)                                                     | Coarse-grained model(s)                              |
+|-------------------------------|-------------------------|-----------------------------------------------------------------------|------------------------------------------------------|
+|Polyethylene oxide             |PEO                      |[gromos2016H66](polyply/data/2016H66/polyether_blocks.ff)              |[martini2](polyply/data/martini2/PEO.martini.2.itp)   |
+|                               |                         |[oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEO.oplsaa.LigParGen.ff)|[martini3](polyply/data/martini3/PEO.martini3.ff)     |
+|Polystyrene                    |PS                       |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |[martini2](polyply/data/martini2/PS.martini.2.itp)    |
+|                               |                         |                                                                       |[martini3](polyply/data/martini3/PS.martini3.ff)      |
+|Polystyrene-b-poly(ethylene oxide)|PS-PEO                |                                                                       |[martini3](polyply/data/martini3/PS_PEO_link.ff)      |
+|Polymethyl acrylate            |PMA                      |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |[martini3](polyply/data/martini3/PMA.martini3.ff)     |
+|Polymethyl methacrylate        |PMMA                     |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |[martini3](polyply/data/martini3/PMMA.martini3.ff)    |
+|Polyethylene                   |PE                       |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |[martini3](polyply/data/martini3/PE.martini3.ff)      |
+|                               |                         |                                                                       |[martini2](polyply/data/martini2/PE.martini.2.itp)    |
+|Polypropylene                  |PP                       |                                                                       |[martini2](polyply/data/martini2/PP.martini.2.itp)    |
+|Poly(3-hexylthiophene)         |P3HT                     |[gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)              |[martini2](polyply/data/martini2/P3HT.martini.2.itp)  |
+|                               |                         |                                                                       |[martini3](polyply/data/martini3/P3HT.martini3.ff)    |
+|Polyvinyl alcohol              |PVA                      |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |[martini3](polyply/data/martini3/PVA.martini3.ff)     |
+|Poly(diallyldimethylammonium)  |PDADMA                   |                                                                       |[martini2](polyply/data/martini2/PDADMA.martini.2.itp)|
+|Polystyrene sulfonate          |PSS                      |                                                                       |[martini2](polyply/data/martini2/PSS.martini.2.itp)   |
+|                               |                         |                                                                       |[martini3](polyply/data/martini3/PSS.martini3.ff)     |
+|Poly(para-phenylene ethynylene)|PPE                      |                                                                       |[martini3](polyply/data/martini3/PPE.martini3.ff)     |
+|Poly(TEMPO methacrylate)       |PTMA                     |                                                                       |[martini3](polyply/data/martini3/PPE.martini3.ff)     |
+|Dextran                        |DEX                      |                                                                       |[martini3](polyply/data/martini3/PTMA.martini3.ff)    |
+|DNA nucleobases                |Dx, Tx5, Dx3 w/ x=T,G,A,C|[parmbsc1](polyply/data/parmbsc1/dna_final.ff)                         |[martini2](polyply/data/martini2/DNA_M2.ff)           |
+|Aminoacids                     |3 letter code            |                                                                       |[martini3](polyply/data/martini3/aminoacids.ff)       |
 

--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -1,7 +1,17 @@
 
-| Polymer name           | Abbreviation | All-atom model(s)                                                       | Coarse-grained model(s)                              |
-|------------------------|--------------|-------------------------------------------------------------------------|------------------------------------------------------|
-| Polyethylene oxide     | PEO          | [gromos2016H66](polyply/data/2016H66/polyether_blocks.ff)               | [Martini 2](polyply/data/martini2/PEO.martini.2.itp) |
-|                        |              | [oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEO.oplsaa.LigParGen.ff) | [Martini 3](polyply/data/martini2/PEO.martini3.ff)   |
-| Poly(3-hexylthiophene) | P3HT         | [gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)               | [Martini 2](polyply/data/martini2/P3HT.martini.2.itp)|
-|                        |              |                                                                         | [Martini 3](polyply/data/martini2/P3HT.martini3.ff)  |
+| Polymer name           | Abbreviation                | All-atom model(s)                                                       | Coarse-grained model(s)                              |
+|------------------------|-----------------------------|-------------------------------------------------------------------------|------------------------------------------------------|
+| Polyethylene oxide     | PEO                         | [gromos2016H66](polyply/data/2016H66/polyether_blocks.ff)               | [martini2](polyply/data/martini2/PEO.martini.2.itp)  |
+|                        |                             | [oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEO.oplsaa.LigParGen.ff) | [martini3](polyply/data/martini3/PEO.martini3.ff)    |
+| Polystyrene            | PS                          | [gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               | [martini2](polyply/data/martini2/PS.martini.2.itp)   |
+|                        |                             |                                                                         | [martini3](polyply/data/martini3/PS.martini3.ff)     |
+| Polymethyl acrylate    | PMA                         | [gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               | [martini3](polyply/data/martini3/PMA.martini3.ff)    |
+| Polymethyl methacrylate| PMMA                        | [gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               | [martini3](polyply/data/martini3/PMMA.martini3.ff)   |
+| Polyethylene           | PE                          | [gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               | [martini3](polyply/data/martini3/PE.martini3.ff)     |
+| Poly(3-hexylthiophene) | P3HT                        | [gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)               | [martini2](polyply/data/martini2/P3HT.martini.2.itp) |
+|                        |                             |                                                                         | [martini3](polyply/data/martini3/P3HT.martini3.ff)   |
+| Polyvinyl alcohol      | PVA                         | [gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)               | [martini3](polyply/data/martini3/PVA.martini3.ff)    |
+| Dextran                | DEX                         |                                                                         | [martini3](polyply/data/martini3/dextran.martini3.ff)|
+| DNA nucleobases        | Dx, Tx5, Dx3 with x=T,G,A,C | [parmbsc1](polyply/data/parmbsc1/dna_final.ff)                          |                                                      |
+| Aminoacids             | 3 letter code               |                                                                         | [martini3](polyply/data/martini3/aminoacids.ff)      |
+

--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -10,7 +10,7 @@
 |Polymethyl methacrylate        |PMMA                     |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |[martini3](polyply/data/martini3/PMMA.martini3.ff)    |
 |Polyethylene                   |PE                       |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |[martini3](polyply/data/martini3/PE.martini3.ff)      |
 |                               |                         |                                                                       |[martini2](polyply/data/martini2/PE.martini.2.itp)    |
-|Polypropylene                  |PP                       |                                                                       |[martini2](polyply/data/martini2/PP.martini.2.itp)    |
+|Polypropylene                  |PP                       |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |[martini2](polyply/data/martini2/PP.martini.2.itp)    |
 |Poly(3-hexylthiophene)         |P3HT                     |[gromos53A6](polyply/data/gromos53A6/P3HT.gromos.53A6.ff)              |[martini2](polyply/data/martini2/P3HT.martini.2.itp)  |
 |                               |                         |                                                                       |[martini3](polyply/data/martini3/P3HT.martini3.ff)    |
 |Polyvinyl alcohol              |PVA                      |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              |[martini3](polyply/data/martini3/PVA.martini3.ff)     |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ force-field, molecule parameters and this program.
 ## Quick references
 [Installation Guide](https://github.com/marrink-lab/polyply_1.0/wiki/Installation)\
 [FAQs](https://github.com/marrink-lab/polyply_1.0/wiki/FAQs)\
+[Current Polyply Polymer Library](./LIBRARY.md)\
 [Submissions to Martini Polymer Library](https://github.com/marrink-lab/polyply_1.0/wiki/Submit-polymer-parameters)\
 [Tutorial: Martini Polymers](https://github.com/marrink-lab/polyply_1.0/wiki/Tutorial:-martini-polymer-melts)\
 [Tutorial: GROMOS Polymers](https://github.com/marrink-lab/polyply_1.0/wiki/Tutorial:-GROMOS-polymer-melts)\


### PR DESCRIPTION
I had this idea and wanted to run it with you, @fgrunewald. It might be useful to have this somewhere for users that want to know whether a certain polymer is already in the polyply library (without having to install polyply). It could then [be linked](https://github.com/ricalessandri/polyply_1.0/blob/library-table/LIBRARY.md) in the main README.

Let me know what you think, this is a draft so many things could be improved (including maybe automating the table generation...). But wanted to first check if this is of any interest.