### PR TITLE
Add error message for missing `-seq`

### DIFF
--- a/polyply/src/gen_seq.py
+++ b/polyply/src/gen_seq.py
@@ -226,6 +226,10 @@ def generate_seq_graph(sequence, macros, connects):
     `:class:networkx.graph`
     """
     seq_graph = nx.Graph()
+    if sequence is None:
+        msg = ("`sequence` is empty; maybe you forgot to pass the -seq command to `polyply gen_seq`?")
+        raise IOError(msg)
+
     for idx, macro_name in enumerate(sequence):
         sub_graph = macros[macro_name].gen_graph()
 


### PR DESCRIPTION
Currently, one gets the following error message if one forgets the `-seq` command line argument when using `polyply gen_seq`:

```
Traceback (most recent call last):
  File "/Users/alessandri/miniconda3/envs/polyply/bin/polyply", line 258, in <module>
    main()
  File "/Users/alessandri/miniconda3/envs/polyply/bin/polyply", line 254, in main
    subprogram(**args_dict)
  File "/Users/alessandri/miniconda3/envs/polyply/lib/python3.10/site-packages/polyply/src/gen_seq.py", line 377, in gen_seq
    seq_graph = generate_seq_graph(seq, macros, connects)
  File "/Users/alessandri/miniconda3/envs/polyply/lib/python3.10/site-packages/polyply/src/gen_seq.py", line 229, in generate_seq_graph
    for idx, macro_name in enumerate(sequence):
TypeError: 'NoneType' object is not iterable
```
which is kinda criptic.

With this PR, one gets the following error message:
```
Traceback (most recent call last):
  File "/Users/alessandri/miniconda3/envs/polyply/bin/polyply", line 258, in <module>
    main()
  File "/Users/alessandri/miniconda3/envs/polyply/bin/polyply", line 254, in main
    subprogram(**args_dict)
  File "/Users/alessandri/miniconda3/envs/polyply/lib/python3.10/site-packages/polyply/src/gen_seq.py", line 381, in gen_seq
    seq_graph = generate_seq_graph(seq, macros, connects)
  File "/Users/alessandri/miniconda3/envs/polyply/lib/python3.10/site-packages/polyply/src/gen_seq.py", line 231, in generate_seq_graph
    raise IOError(msg)
OSError: `sequence` is empty; maybe you forgot to pass the -seq command to `polyply gen_seq`?
```
which I think would help the user better. What do you think? 

I coded this up quickly by looking at other error messages but let me know if I did something wrong. I tested the code and the message is printed out when it should. Please also suggest how to improve the message if needed.