### PR TITLE
Input cleaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ est.pdb
 **.pyc
 **.bak
 
+*.idea
+
 **.lprof
 polyply.egg-info
 

--- a/bin/polyply
+++ b/bin/polyply
@@ -81,7 +81,7 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
     #           Input Arguments for the coordinate generation tool
     # ============================================================================
 
-    parser_gen_coords.add_argument('-name', required=True, type=str, dest="name",
+    parser_gen_coords.add_argument('-name', required=False, type=str, dest="name", default='molname',
                                    help="name of the final molecule")
 
     parser_gen_coords.add_argument('-v', dest='verbosity', action='count',
@@ -91,7 +91,7 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
     file_group = parser_gen_coords.add_argument_group('Input and output files')
     file_group.add_argument('-p', dest='toppath', required=False, type=Path,
                             help='topology file (.top)')
-    file_group.add_argument('-o', dest='outpath', type=Path,
+    file_group.add_argument('-o', dest='outpath', type=Path, default='coords.gro',
                             help='output GRO (.gro)')
     file_group.add_argument('-c', dest='coordpath', type=Path,
                             help='input file molecules (.gro)', default=None)
@@ -197,7 +197,7 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
                                   "is <tag:molecule name>.")
 
     seq_group = parser_gen_seq.add_argument_group('Definition of sequence')
-    seq_group.add_argument('-seq', dest='seq', nargs='+', type=str,
+    seq_group.add_argument('-seq', dest='seq', nargs='+', type=str, required=True,
                            help="Define the sequence order in which to combine macros."
                                 "The format is <macro_tag, macro_tag, ...>. For example, "
                                 "to combine three blocks called A, B, which are defined by the "

--- a/polyply/src/gen_seq.py
+++ b/polyply/src/gen_seq.py
@@ -226,6 +226,10 @@ def generate_seq_graph(sequence, macros, connects):
     `:class:networkx.graph`
     """
     seq_graph = nx.Graph()
+    if sequence is None:
+        msg = ("sequence is empty; you need to provide a sequence to gen_seq")
+        raise IOError(msg)
+
     for idx, macro_name in enumerate(sequence):
         sub_graph = macros[macro_name].gen_graph()
 


### PR DESCRIPTION
Following #311 and #295, this PR:

- removes having to use -name in gen_coords
- gives a default output file name of `coords.gro` in gen_coords if `-o` is not specified
- includes @ricalessandri's error messaging in #295

