### PR TITLE
Implement frame based backmapping protocol

### DIFF
--- a/bin/polyply
+++ b/bin/polyply
@@ -162,6 +162,9 @@ def main(): # pylint: disable=too-many-locals,too-many-statements
                                          ' when RW fails in first attempt'))
 
     backmap_group = parser_gen_coords.add_argument_group('Options for backmapping')
+    backmap_group.add_argument('-protocol', dest='protocol', type=str, default='bonds',
+                               choices=['bonds', 'frames'],
+                               help='choose the protocol to use for template orientation.')
     backmap_group.add_argument('-back_fudge', dest='bfudge', type=float, default=0.4,
                                help='factor by which to scale the coordinates when backmapping.')
 

--- a/polyply/src/gen_coords.py
+++ b/polyply/src/gen_coords.py
@@ -116,6 +116,7 @@ def gen_coords(toppath,
                max_force=5*10**4.0,
                nrewind=5,
                lib=None,
+               protocol='bonds',
                bfudge=0.4):
     """
     Subprogram for coordinate generation which implements the default
@@ -261,7 +262,7 @@ def gen_coords(toppath,
                 nrewind=nrewind).run_system(topology.molecules)
     ligand_annotator.split_ligands()
     LOGGER.info("backmapping to target resolution",  type="step")
-    Backmap(fudge_coords=bfudge).run_system(topology)
+    Backmap(fudge_coords=bfudge, protocol=protocol).run_system(topology)
     # Write output
     LOGGER.info("writing output",  type="step")
     command = ' '.join(sys.argv)

--- a/polyply/src/gen_moving_frame.py
+++ b/polyply/src/gen_moving_frame.py
@@ -1,0 +1,244 @@
+# Copyright 2020 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import networkx as nx
+
+from .linalg_functions import u_vect, rotate_from_vect, \
+                        finite_difference_O5, finite_difference_O1
+
+"""
+Linear algebra class which constructs a rotation minimizing
+frame along a linear meta_molecule.
+"""
+
+def calc_tangents(curve):
+    """
+    Compute the tangent vectors for a discrete 'curve'. If enough
+    data points are available the tangents are calculated using
+    a fifth order finite difference, else the function reverts to
+    a first order finite difference.
+
+    Parameters
+    ---------
+    curve: numpy.ndarray
+        A ndarray, of shape (N, 3), corresponding to the
+        coordinates of a discrete curve
+
+    Returns
+    ---------
+    dX: numpy.ndarray
+        A ndarray, of shape (N, 3), corresponding
+        to the tangent vectors of X
+    """
+    if len(curve) > 4:
+        curve_tangents = finite_difference_O5(curve)
+    else:
+        curve_tangents = finite_difference_O1(curve)
+    return curve_tangents
+
+def gen_next_normal(current_frame, next_frame):
+    """
+    Generate a normal vector that determines the next frame and
+    that is rotation minimizing with respect to the current orthonormal
+    frame. Here we use the double reflection method by Wang et al.
+    (DOI:10.1145/1330511.1330513)
+
+    Parameters
+    ---------
+    current_frame: tuple
+        containing information of the current orthonormal frame,
+        i.e. the coordinate(r1), tangent(t1) and normal(n1) vector.
+    next_frame: tuple
+        containing information of the next frame that we want
+        to define, i.e. the coordinate(r2) and tangent(t2) vector.
+
+    Returns
+    ---------
+    normal: np.ndarray
+        vector determining next_frame
+    """
+    r1, t1, n1 = current_frame
+    r2, t2 = next_frame
+
+    vec1 = r2 - r1
+    norm1 = vec1 @ vec1
+    Rl = n1 - (2/norm1) * (vec1 @ n1) * vec1
+    Tl = t1 - (2/norm1) * (vec1 @ t1) * vec1
+    vec2 = t2 - Tl
+    norm2 = vec2 @ vec2
+    n2 = Rl - (2/norm2) * (vec2 @ Rl) * vec2
+    normal = u_vect(n2)
+    return normal
+
+def rotation_min_frame(curve):
+    """
+    Construct a rotation minimizing frame along
+    a discrete 'curve' using the double reflection method.
+
+    Parameters
+    ---------
+    curve: numpy.ndarray
+        discrete curve coordinates, ndarray of shape (N, 3)
+
+    Returns
+    ---------
+    tangent, normals, binormals: tuple
+        All three ndarray, of shape (N, 3), corresponding
+        to the reference vectors along curve
+    """
+    # Calculate tangents
+    tangents = calc_tangents(curve)
+    tangents = np.apply_along_axis(u_vect, axis=1, arr=tangents)
+
+    # Initialize the reference/normal vector
+    normals = np.zeros_like(curve)
+    if np.any(tangents[0, :2]):
+        normals[0] = [tangents[0, 1], -tangents[0, 0], 0.0]
+    elif np.any(tangents[0, 2:]):
+        normals[0] = [0.0, tangents[0, 2], -tangents[0, 1]]
+    else:
+            msg = ('\n Not able to create DNA strands'
+                   'Check the provided DNA coordinates')
+            raise IOError(msg)
+    normals[0] = u_vect(normals[0])
+
+    # Construct reference vectors along curve using double reflection
+    for i in range(len(tangents) - 1):
+        normals[i+1] = gen_next_normal((curve[i], tangents[i], normals[i]),
+                                       (curve[i+1], tangents[i+1]))
+
+    # Calculate the rotated binormals
+    binormals = np.cross(tangents, normals)
+    return tangents, normals, binormals
+
+def close_frame(curve, tangents, normals, binormals, rotation_per_bp):
+    """
+    Uniformly distribute the corrective twist needed to close
+    the moving frame on a cyclic curve. The Uniform distribution
+    of excess curvatures, minimizes the total squared angular
+    speed of the moving frame.
+
+    Parameters
+    ---------
+    curve: numpy.ndarray
+        ndarray of shape (N, 3)
+    tangents: numpy.ndarray
+        ndarray of shape (N, 3)
+    normals: numpy.ndarray
+        ndarray of shape (N, 3)
+    binormals: numpy.ndarray
+        ndarray of shape (N, 3)
+
+    Returns
+    ---------
+    tangent, normals, coords: tuple
+        All three ndarray, of shape (N, 3), corresponding
+        to the reference vectors along cyclic curve
+    """
+    # Determine the minimal rotating normal vector wrt. last reference frame
+    target_normal = gen_next_normal((curve[-1], tangents[-1], normals[-1]),
+                                    (curve[0], tangents[0]))
+    # Calculate rotation needed to match the normals
+    phi = np.arccos(target_normal @ normals[0]) - rotation_per_bp
+
+    # Distribute corrective curvature over curve
+    correction_per_base = phi / (len(tangents) - 1)
+    for ndx in range(1, len(tangents)):
+        rotation_vector = correction_per_base * ndx * tangents[ndx]
+        normals[ndx] = rotate_from_vect(normals[ndx], rotation_vector)
+        binormals[ndx] = np.cross(tangents[ndx], normals[ndx])
+    return tangents, normals, binormals
+
+def dna_frame(meta_molecule, curve, rotation_per_bp):
+    # Generate rotation minimizing frame on curve
+    tangents, normals, binormals = rotation_min_frame(curve)
+
+    # Rotate moving frame to introduce intrinsic DNA twist
+    rotation_vectors = [vec * rotation_per_bp *
+                        i for i, vec in enumerate(tangents, start=1)]
+    for ndx, vector in enumerate(rotation_vectors):
+        normals[ndx] = rotate_from_vect(normals[ndx], vector)
+        binormals[ndx] = rotate_from_vect(binormals[ndx], vector)
+
+    # Comply with boundary conditions if DNA is closed
+    if nx.cycle_basis(meta_molecule):
+        tangents, normals, binormals = close_frame(curve, tangents,
+                                                   normals, binormals,
+                                                   rotation_per_bp)
+    return tangents, normals, binormals
+
+
+class ConstructFrame:
+    """
+    Generate a rotating and moving frame over a meta_molecule.
+    """
+
+    def __init__(self, rotation_per_bp=0.59):
+        self.rotation_per_bp = rotation_per_bp  # 34° in radian
+
+    def run(self, meta_molecule):
+        """
+        Construct the moving frame. If the user provides base orientations,
+        these are used. Otherwise, first a rotation minimizing frame is
+        created along the 'meta_molecule' coordinates. An intrinsic twist
+        is added to the moving frame to incorporate the DNA double-helix.
+        Lastly, if the 'meta_molecule' is cyclical, a corrective twist
+        is added in order to close the moving frame.
+
+        Parameters
+        ----------
+        meta_molecule: :class:`polyply.src.MetaMolecule`
+
+        Returns
+        ----------
+        moving_frame: numpy.ndarray
+            ndarray of shape (N, (3, 3))
+
+        """
+        # Read positions from meta_molecule
+        position_dictionary = nx.get_node_attributes(meta_molecule, "position")
+        curve = np.array(list(position_dictionary.values()))
+
+        if not nx.get_node_attributes(meta_molecule, "normal"):
+            tangents, normals, binormals = dna_frame(meta_molecule, curve,
+                                                     self.rotation_per_bp)
+        else:
+            # Read normals from meta_molecule
+            normals = nx.get_node_attributes(meta_molecule, "normal")
+            normals = np.asarray(list(normals.values()))
+            normals = np.apply_along_axis(u_vect, axis=1, arr=normals)
+
+            if not nx.get_node_attributes(meta_molecule, "tangent"):
+                tangents = calc_tangents(curve)
+                # Apply Gram–Schmidt orthogonalization
+                tangents -= np.dot(normals, tangents) * normals
+                tangents = np.apply_along_axis(u_vect, axis=1, arr=tangents)
+            else:
+                # Read tangents from meta_molecule
+                tangents = nx.get_node_attributes(meta_molecule, "tangent")
+                tangents = np.asarray(list(tangents.values()))
+                tangents = np.apply_along_axis(u_vect, axis=1, arr=tangents)
+
+            if not nx.get_node_attributes(meta_molecule, "binormals"):
+                binormals = np.cross(tangents, normals)
+            else:
+                # Read binormals from meta_molecule
+                binormals = nx.get_node_attributes(meta_molecule, "binormals")
+                binormals = np.asarray(list(binormals.values()))
+                binormals = np.apply_along_axis(u_vect, axis=1, arr=binormals)
+
+        # Construct frame out of generated vectors
+        moving_frame = [np.stack((i, j, k), axis=1)
+                       for i, j, k in zip(normals, binormals, tangents)]
+        return moving_frame

--- a/polyply/src/orient_by_bonds.py
+++ b/polyply/src/orient_by_bonds.py
@@ -1,0 +1,119 @@
+import numpy as np
+import scipy.optimize
+import networkx as nx
+from .generate_templates import find_atoms
+from .linalg_functions import rotate_xyz
+from .graph_utils import find_connecting_edges
+from .linalg_functions import norm_matrix
+
+def orient_by_bonds(meta_molecule, current_node, template, built_nodes):
+    """
+    Given a `template` and a `node` of a `meta_molecule` at lower resolution
+    find the bonded interactions connecting the higher resolution template
+    to its neighbours and orient a template such that the atoms point torwards
+    the neighbours. In case some nodes of meta_molecule have already been built
+    at the lower resolution they can be provided as `built_nodes`. In case the
+    lower resolution is already built the atoms will be oriented torward the lower
+    resolution atom participating in the bonded interaction.
+
+    Parameters:
+    -----------
+    meta_molecule: :class:`polyply.src.meta_molecule`
+    current_node:
+        node key of the node in meta_molecule to which template referes to
+    template: dict[collections.abc.Hashable, np.ndarray]
+        dict of positions referring to the lower resolution atoms of node
+    built_nodes: list
+        list of meta_molecule node keys of residues that are already built
+
+    Returns:
+    --------
+    dict
+        the oriented template
+    """
+    # 1. find neighbours at meta_mol level
+    neighbours = nx.all_neighbors(meta_molecule, current_node)
+    current_resid = meta_molecule.nodes[current_node]["resid"]
+
+    # 2. find connecting atoms at low-res level
+    edges = []
+    ref_nodes = []
+    for node in neighbours:
+        resid = meta_molecule.nodes[node]["resid"]
+        edge = find_connecting_edges(meta_molecule,
+                                     meta_molecule.molecule,
+                                     (node, current_node))
+        edges += edge
+        ref_nodes.extend([node]*len(edge))
+
+    # 3. build coordinate system
+    ref_coords = np.zeros((3, len(edges)))
+    opt_coords = np.zeros((3, len(edges)))
+
+    for ndx, edge in enumerate(edges):
+        for atom in edge:
+            resid = meta_molecule.molecule.nodes[atom]["resid"]
+            if resid == current_resid:
+                current_atom = atom
+            else:
+                ref_atom = atom
+                ref_resid = resid
+
+        # the reference residue has already been build so we take the lower
+        # resolution coordinates as reference
+        if ref_resid in built_nodes:
+            atom_name = meta_molecule.molecule.nodes[current_atom]["atomname"]
+
+            # record the coordinates of the atom that is rotated
+            opt_coords[:, ndx] = template[atom_name]
+
+            # given the reference atom that already exits translate it to the origin
+            # of the rotation, this will be the reference point for rotation
+            ref_coords[:, ndx] = meta_molecule.molecule.nodes[ref_atom]["position"] -\
+                                 meta_molecule.nodes[current_node]["position"]
+
+        # the reference residue has not been build the CG center is taken as
+        # reference
+        else:
+            atom_name = meta_molecule.molecule.nodes[current_atom]["atomname"]
+            cg_node = ref_nodes[ndx] #find_atoms(meta_molecule, "resid", ref_resid)[0]
+
+            # record the coordinates of the atom that is rotated
+            opt_coords[:, ndx] = template[atom_name]
+
+            # as the reference atom is not built take the cg node as reference point
+            # for rotation; translate it to origin
+            ref_coords[:, ndx] = meta_molecule.nodes[cg_node]["position"] -\
+                                 meta_molecule.nodes[current_node]["position"]
+
+
+    # 4. optimize the distance between reference nodes and nodes to be placed
+    # only using rotation of the complete template
+    #@profile
+    def target_function(angles):
+        rotated = rotate_xyz(opt_coords, angles[0], angles[1], angles[2])
+        diff = rotated - ref_coords
+        score = norm_matrix(diff)
+        return score
+
+    # choose random starting angles
+    angles = np.random.uniform(low=0, high=2*np.pi, size=(3))
+    opt_results = scipy.optimize.minimize(target_function, angles, method='L-BFGS-B',
+                                          options={'ftol':0.01, 'maxiter': 400})
+
+    # 5. write the template as array and rotate it corrsponding to the result above
+    template_arr = np.zeros((3, len(template)))
+    key_to_ndx = {}
+    for ndx, key in enumerate(template.keys()):
+        template_arr[:, ndx] = template[key]
+        key_to_ndx[key] = ndx
+
+    angles = opt_results['x']
+    template_rotated_arr = rotate_xyz(template_arr, angles[0], angles[1], angles[2])
+
+    # 6. write the template back as dictionary
+    template_rotated = {}
+    for key, ndx in key_to_ndx.items():
+        template_rotated[key] = template_rotated_arr[:, ndx]
+
+    return template_rotated

--- a/polyply/src/orient_by_frames.py
+++ b/polyply/src/orient_by_frames.py
@@ -1,0 +1,43 @@
+import numpy as np
+from .gen_moving_frame import ConstructFrame
+
+def orient_by_frames(meta_molecule, current_node, template, built_nodes):
+    """
+    Given a `template` and a `node` of a `meta_molecule` at lower resolution
+    align the template to a constructed rotation minimizing frame.
+
+    Parameters:
+    -----------
+    meta_molecule: :class:`polyply.src.meta_molecule`
+    current_node:
+        node key of the node in meta_molecule to which template referes to
+    template: dict[collections.abc.Hashable, np.ndarray]
+        dict of positions referring to the lower resolution atoms of node
+    built_nodes: list
+        list of meta_molecule node keys of residues that are already built
+
+    Returns:
+    --------
+    dict
+        the oriented template
+    """
+
+    rotation_per_bp = .34
+    construct_frame = ConstructFrame(rotation_per_bp=rotation_per_bp)
+    moving_frame = construct_frame.run(meta_molecule)
+
+    # Write the template as array
+    template_arr = np.zeros((3, len(template)))
+    key_to_ndx = {}
+    for ndx, key in enumerate(template.keys()):
+        template_arr[:, ndx] = template[key]
+        key_to_ndx[key] = ndx
+
+    template_rotated_arr = moving_frame[current_node] @ template_arr
+
+    # Write the template back as dictionary
+    template_rotated = {}
+    for key, ndx in key_to_ndx.items():
+        template_rotated[key] = template_rotated_arr[:, ndx]
+
+    return template_rotated


### PR DESCRIPTION
Extend the gen_coords processor to allow for more backmapping protocols. As a first example, a frame-based protocol will be implemented, which places molecule templates on generated or user-provided orientation frames.

The main aim of this backmapping protocol is currently to allow for the construction of double-stranded DNA molecules.