### PR TITLE
Contribute PVA OPLS-AA/LigParGen .ff file

### DIFF
--- a/polyply/data/oplsaaLigParGen/PVA.oplsaa.LigParGen.ff
+++ b/polyply/data/oplsaaLigParGen/PVA.oplsaa.LigParGen.ff
@@ -1,0 +1,220 @@
+[ moleculetype ]
+PVA                   3
+[ atoms ]
+    1 opls_135     1      PVA     C01     1   -0.2549   12.0110
+    2 opls_135     1      PVA     C02     2    0.0816   12.0110
+    3 opls_154     1      PVA     O03     3   -0.5880   15.9990
+    4 opls_140     1      PVA     H04     4    0.1060    1.0080
+    5 opls_140     1      PVA     H05     5    0.1060    1.0080
+    6 opls_140     1      PVA     H06     6    0.1406    1.0080
+    7 opls_004     1      PVA     H07     7    0.4087    1.0080
+[ bonds ]
+    2     1     1    0.1529    224262.400
+    3     2     1    0.1410    267776.000
+    4     1     1    0.1090    284512.000
+    5     1     1    0.1090    284512.000
+    6     2     1    0.1090    284512.000
+    7     3     1    0.0945    462750.400
+[ angles ]
+    1     2     3     1    109.500   418.400
+    1     2     6     1    110.700   313.800
+    2     3     7     1    108.500   460.240
+    3     2     6     1    109.500   292.880
+    2     1     4     1    110.700   313.800
+    4     1     5     1    107.800   276.144
+    2     1     5     1    110.700   313.800
+[ dihedrals ]
+[ dihedrals ]
+    6     2     1     5     3      0.628      1.883      0.000     -2.510     -0.000      0.000
+    6     2     1     4     3      0.628      1.883      0.000     -2.510     -0.000      0.000
+    4     1     2     3     3      0.979      2.937      0.000     -3.916     -0.000      0.000
+    5     1     2     3     3      0.979      2.937      0.000     -3.916     -0.000      0.000
+    7     3     2     1     3     -0.444      3.833      0.728     -4.117     -0.000      0.000
+    7     3     2     6     3      0.736      2.209      0.000     -2.946     -0.000      0.000
+[ pairs ]
+    3      4       1
+    3      5       1
+    1      7       1
+    4      6       1
+    5      6       1
+    6      7       1
+[ moleculetype ]
+CH3a                   3
+[ atoms ]
+    1 opls_135     1     CH3a      C1     1   -0.2397   12.0110
+    2 opls_140     1     CH3a      H1     2    0.0799    1.0080
+    3 opls_140     1     CH3a      H2     3    0.0799    1.0080
+    4 opls_140     1     CH3a      H3     4    0.0799    1.0080
+[ bonds ]
+    2     1     1    0.1090    284512.000
+    3     1     1    0.1090    284512.000
+    4     1     1    0.1090    284512.000
+[ angles ]
+    3     1     4     1    107.800   276.144
+    2     1     3     1    107.800   276.144
+    2     1     4     1    107.800   276.144
+[ dihedrals ]
+[ dihedrals ]
+[ pairs ]
+[ moleculetype ]
+CH3b                   3
+[ atoms ]
+    1 opls_135     1     CH3b      C1     1   -0.2814   12.0110
+    2 opls_140     1     CH3b      H1     2    0.0938    1.0080
+    3 opls_140     1     CH3b      H2     3    0.0938    1.0080
+    4 opls_140     1     CH3b      H3     4    0.0938    1.0080
+[ bonds ]
+    2     1     1    0.1090    284512.000
+    3     1     1    0.1090    284512.000
+    4     1     1    0.1090    284512.000
+[ angles ]
+    2     1     4     1    107.800   276.144
+    2     1     3     1    107.800   276.144
+    3     1     4     1    107.800   276.144
+[ dihedrals ]
+[ dihedrals ]
+[ pairs ]
+[link]
+resname "PVA"
+[ atoms ]
+[ bonds ]
+ +C01   C02     1    0.1529    224262.400   {"comment":"intermonomer"}
+[ angles ]
+  C01   C02  +C01     1    112.700   488.273   {"comment":"intermonomer"}
+  C02  +C01  +C02     1    112.700   488.273   {"comment":"intermonomer"}
+  C02  +C01  +H04     1    110.700   313.800   {"comment":"intermonomer"}
+  C02  +C01  +H05     1    110.700   313.800   {"comment":"intermonomer"}
+  O03   C02  +C01     1    109.500   418.400   {"comment":"intermonomer"}
+ +C01   C02   H06     1    110.700   313.800   {"comment":"intermonomer"}
+[ dihedrals ]
+[ dihedrals ]
+ +C02  +C01   C02   C01     3      2.301     -1.464      0.837     -1.674     -0.000      0.000   {"comment":"intermonomer"}
+ +C02  +C01   C02   O03     3     -3.247      3.247      0.000     -0.000     -0.000      0.000   {"comment":"intermonomer"}
+ +H06  +C02  +C01   C02     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"intermonomer"}
+  H04   C01   C02  +C01     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"intermonomer"}
+ +H05  +C01   C02   C01     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"intermonomer"}
+ +H04  +C01   C02   C01     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"intermonomer"}
+  H06   C02  +C01  +C02     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"intermonomer"}
+  H05   C01   C02  +C01     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"intermonomer"}
+ +H05  +C01   C02   H06     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"intermonomer"}
+ +H04  +C01   C02   H06     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"intermonomer"}
+ +H05  +C01   C02   O03     3      0.979      2.937      0.000     -3.916     -0.000      0.000   {"comment":"intermonomer"}
+ +H04  +C01   C02   O03     3      0.979      2.937      0.000     -3.916     -0.000      0.000   {"comment":"intermonomer"}
+  H07   O03   C02  +C01     3     -0.444      3.833      0.728     -4.117     -0.000      0.000   {"comment":"intermonomer"}
+ +O03  +C02  +C01   C02     3     -3.247      3.247      0.000     -0.000     -0.000      0.000   {"comment":"intermonomer"}
+[ pairs ]
+  C01   +C02       1   {"comment":"intermonomer"}
+  O03   +C02       1   {"comment":"intermonomer"}
+  C02   +O03       1   {"comment":"intermonomer"}
+ +C01    H04       1   {"comment":"intermonomer"}
+ +C01    H05       1   {"comment":"intermonomer"}
+  C01   +H04       1   {"comment":"intermonomer"}
+  C01   +H05       1   {"comment":"intermonomer"}
+ +C02    H06       1   {"comment":"intermonomer"}
+ +C01    H07       1   {"comment":"intermonomer"}
+  O03   +H04       1   {"comment":"intermonomer"}
+  O03   +H05       1   {"comment":"intermonomer"}
+  C02   +H06       1   {"comment":"intermonomer"}
+  H06   +H04       1   {"comment":"intermonomer"}
+  H06   +H05       1   {"comment":"intermonomer"}
+[link]
+; for bonded terms spanning three residues
+resname "PVA"
+[dihedrals]
+++C01  +C02  +C01   C02     3      2.301     -1.464      0.837     -1.674     -0.000      0.000   {"comment":"intermonomer"}
+[pairs]
+  C02  ++C01       1   {"comment":"intermonomer"}
+[link]
+resname "CH3a|PVA"
+[ atoms ]
+[ bonds ]
+ +C01    C1     1    0.1529    224262.400   {"comment":"alpha-C-link"}
+[ angles ]
+   C1  +C01  +C02     1    112.700   488.273   {"comment":"alpha-C-link"}
+ +C01    C1    H1     1    110.700   313.800   {"comment":"alpha-C-link"}
+ +C01    C1    H2     1    110.700   313.800   {"comment":"alpha-C-link"}
+ +C01    C1    H3     1    110.700   313.800   {"comment":"alpha-C-link"}
+   C1  +C01  +H04     1    110.700   313.800   {"comment":"alpha-C-link"}
+   C1  +C01  +H05     1    110.700   313.800   {"comment":"alpha-C-link"}
+[ dihedrals ]
+[ dihedrals ]
+   H3    C1  +C01  +C02     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"alpha-C-link"}
+   H1    C1  +C01  +C02     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"alpha-C-link"}
+   H2    C1  +C01  +C02     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"alpha-C-link"}
+ +H06  +C02  +C01    C1     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"alpha-C-link"}
+ +H04  +C01    C1    H2     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"alpha-C-link"}
+ +H04  +C01    C1    H3     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"alpha-C-link"}
+ +H05  +C01    C1    H3     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"alpha-C-link"}
+ +H05  +C01    C1    H2     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"alpha-C-link"}
+ +H04  +C01    C1    H1     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"alpha-C-link"}
+ +H05  +C01    C1    H1     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"alpha-C-link"}
+ +O03  +C02  +C01    C1     3     -3.247      3.247      0.000     -0.000     -0.000      0.000   {"comment":"alpha-C-link"}
+[ pairs ]
+   C1   +O03       1   {"comment":"alpha-C-link"}
+ +C02     H1       1   {"comment":"alpha-C-link"}
+ +C02     H2       1   {"comment":"alpha-C-link"}
+ +C02     H3       1   {"comment":"alpha-C-link"}
+   C1   +H06       1   {"comment":"alpha-C-link"}
+   H1   +H04       1   {"comment":"alpha-C-link"}
+   H2   +H04       1   {"comment":"alpha-C-link"}
+   H1   +H05       1   {"comment":"alpha-C-link"}
+   H3   +H04       1   {"comment":"alpha-C-link"}
+   H2   +H05       1   {"comment":"alpha-C-link"}
+   H3   +H05       1   {"comment":"alpha-C-link"}
+[link]
+; for bonded terms spanning three residues
+resname "CH3a|PVA"
+[dihedrals]
+++C01  +C02  +C01    C1     3      2.301     -1.464      0.837     -1.674     -0.000      0.000   {"comment":"alpha-C-link"}
+[pairs]
+   C1  ++C01       1   {"comment":"alpha-C-link"}
+[link]
+resname "PVA|CH3b"
+[ atoms ]
+[ bonds ]
+   C1  -C02     1    0.1529    224262.400   {"comment":"beta-C-link"}
+[ angles ]
+ -C01  -C02    C1     1    112.700   488.273   {"comment":"beta-C-link"}
+ -C02    C1    H1     1    110.700   313.800   {"comment":"beta-C-link"}
+ -C02    C1    H2     1    110.700   313.800   {"comment":"beta-C-link"}
+ -C02    C1    H3     1    110.700   313.800   {"comment":"beta-C-link"}
+ -O03  -C02    C1     1    109.500   418.400   {"comment":"beta-C-link"}
+   C1  -C02  -H06     1    110.700   313.800   {"comment":"beta-C-link"}
+[ dihedrals ]
+[ dihedrals ]
+ -H05  -C01  -C02    C1     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"beta-C-link"}
+   H2    C1  -C02  -C01     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"beta-C-link"}
+   H3    C1  -C02  -C01     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"beta-C-link"}
+ -H04  -C01  -C02    C1     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"beta-C-link"}
+   H1    C1  -C02  -C01     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"beta-C-link"}
+   H1    C1  -C02  -H06     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"beta-C-link"}
+   H2    C1  -C02  -H06     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"beta-C-link"}
+   H3    C1  -C02  -H06     3      0.628      1.883      0.000     -2.510     -0.000      0.000   {"comment":"beta-C-link"}
+   H3    C1  -C02  -O03     3      0.979      2.937      0.000     -3.916     -0.000      0.000   {"comment":"beta-C-link"}
+   H1    C1  -C02  -O03     3      0.979      2.937      0.000     -3.916     -0.000      0.000   {"comment":"beta-C-link"}
+   H2    C1  -C02  -O03     3      0.979      2.937      0.000     -3.916     -0.000      0.000   {"comment":"beta-C-link"}
+ -H07  -O03  -C02    C1     3     -0.444      3.833      0.728     -4.117     -0.000      0.000   {"comment":"beta-C-link"}
+[ pairs ]
+   C1   -H04       1   {"comment":"beta-C-link"}
+   C1   -H05       1   {"comment":"beta-C-link"}
+ -C01     H1       1   {"comment":"beta-C-link"}
+ -C01     H2       1   {"comment":"beta-C-link"}
+   C1   -H07       1   {"comment":"beta-C-link"}
+ -O03     H1       1   {"comment":"beta-C-link"}
+ -C01     H3       1   {"comment":"beta-C-link"}
+ -O03     H2       1   {"comment":"beta-C-link"}
+ -O03     H3       1   {"comment":"beta-C-link"}
+ -H06     H1       1   {"comment":"beta-C-link"}
+ -H06     H2       1   {"comment":"beta-C-link"}
+ -H06     H3       1   {"comment":"beta-C-link"}
+[link]
+; for bonded terms spanning three residues
+resname "PVA|CH3b"
+[dihedrals]
+   C1  -C02  -C01 --C02     3      2.301     -1.464      0.837     -1.674     -0.000      0.000   {"comment":"beta-C-link"}
+[pairs]
+--C02     C1       1   {"comment":"beta-C-link"}
+[ citation ]
+OPLSLigParGen1
+OPLSLigParGen2
+polyply


### PR DESCRIPTION
This is a self-sufficient PVA `ff` file. 

Usage example to obtain a 10-mer:
```
polyply gen_params -f PVA.ff  -name PVA -seq CH3a:1 PVA:10 CH3b:1 -o PVA_n10_oplsLigParGen.itp
```