### PR TITLE
Raise an issue if a link is not applied correctly

### DIFF
--- a/polyply/src/gen_itp.py
+++ b/polyply/src/gen_itp.py
@@ -102,6 +102,12 @@ def gen_params(name="polymer", outpath=Path("polymer.itp"), inpath=[], lib=None,
     LOGGER.info("applying links between residues",  type="step")
     meta_molecule = ApplyLinks().run_molecule(meta_molecule)
 
+    #Check missing edges and raise issues if links between amino acids are not applied.
+    #Bug if the backbone is correct links between amino acids in a chain are not applied correctly
+    for missing in find_missing_edges(meta_molecule, meta_molecule.molecule):
+        msg = "Link between residue {idxA} {resA} and residue {idxB} {resB} was not applied."
+        LOGGER.warning(msg, **missing)
+    
     # Raise warning if molecule is disconnected
     if not nx.is_connected(meta_molecule.molecule):
         LOGGER.warning("Your molecule consists of disjoint parts."


### PR DESCRIPTION
I noticed a problem creating a peptide chain with a link between 2 non-consecutive amino acids. 
I was not able to fix this issue but I think that the bug is in `apply_links.py` with `_check_relative_order`.
So I just raised an issue in the log, if all the links are not applied correctly. It would be very useful for MAD and also for polyply users.