### PR TITLE
Add PTMA GBNO2 IBI model to polyply library [10.1021/acs.macromol.3c00141] 

### DIFF
--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -22,6 +22,7 @@
 |                               |                         |                                                                       |[martini3](polyply/data/martini3/PSS.martini3.ff)     |
 |Poly(para-phenylene ethynylene)|PPE                      |                                                                       |[martini3](polyply/data/martini3/PPE.martini3.ff)     |
 |Poly(TEMPO methacrylate)       |PTMA                     |                                                                       |[martini3](polyply/data/martini3/PTMA.martini3.ff)    |
+|                               |                         |                                                                       |[ibi_GBNO2](polyply/data/ibi_GBNO2/PTMA.GBNO2.ibi.ff) |
 |Dextran                        |DEX                      |                                                                       |[martini3](polyply/data/martini3/dextran.martini3.ff) |
 |DNA nucleobases                |Dx, Tx5, Dx3 w/ x=T,G,A,C|[parmbsc1](polyply/data/parmbsc1/dna_final.ff)                         |[martini2](polyply/data/martini2/DNA_M2.ff)           |
 |Aminoacids                     |3 letter code            |                                                                       |[martini3](polyply/data/martini3/aminoacids.ff)       |

--- a/polyply/data/ibi_GBNO2/PTMA.GBNO2.ibi.ff
+++ b/polyply/data/ibi_GBNO2/PTMA.GBNO2.ibi.ff
@@ -1,0 +1,75 @@
+[ moleculetype ]
+; name nexcl.
+PTMA     2
+
+[ info ] 
+Nonbonded interaction potentials (and example run) can be found at: https://doi.org/10.5281/zenodo.8287521
+ 
+[ atoms ]
+; id  type  resnr  residu atom  cgnr  charge  mass
+   1   VNL    1     PTMA  VNL    1     0     71.099
+   2   EST    1     PTMA  EST    2     0     29.018
+   3    C1    1     PTMA   C1    3     0     56.108
+   4     U    1     PTMA   NN    4     0      0.000
+   5     U    1     PTMA   OO    5     0      0.000
+   6    C1    1     PTMA   C2    6     0     56.108 
+   7    NO    1     PTMA   NO    7     0     30.006
+ 
+[ bonds ]
+; i  j   funct   length
+  1  2      1     0.35337   12500 
+  2  3      1     0.32325   32000
+  2  6      1     0.32369   32000
+  3  6      1     0.38838   32000
+  3  7      1     0.23794 1000000 {"ifdef": "FLEXIBLE"}
+  6  7      1     0.23793 1000000 {"ifdef": "FLEXIBLE"}
+ 
+[constraints]
+; i  j   funct   length
+  3  7      1     0.23794  {"ifndef": "FLEXIBLE"}
+  6  7      1     0.23793  {"ifndef": "FLEXIBLE"}
+ 
+[ angles ]
+; i  j  k  funct   length  force k
+  1  2  3    2      130.000  90 
+  1  2  6    2      130.000  75 
+
+[dihedrals]
+; i j k l  funct  ref.angle   force_k
+  1 3 6 7    2      165.98      50
+  2 3 6 7    2      179.20      80
+  3 7 5 6    2      170.723     50 
+
+[virtual_sites3]
+; 3fd sites
+; site positioned as a linear combination of 3 atoms; the site is in the same plane
+; site  from      funct    a      b
+   4    3  2  7     2    0.834  0.210
+   5    3  2  7     2    1.180  0.276
+
+[exclusions]
+  1  2  3  4  5  6  7
+  2  3  4  5  6  7
+  3  4  5  6  7
+  4  5  6  7
+  5  6  7
+  6  7
+
+[ link ]
+resname "PTMA"
+[ bonds ]
+VNL     +VNL    1     0.305 12000  {"group": "vinyl backbone"}
+
+[ link ]
+resname "PTMA"
+[ angles ]
+VNL  +VNL  ++VNL   2  126  40  {"group": "vinyl backbone"}
+
+[ link ]
+resname "PTMA"
+[ angles ]
+EST  VNL  +VNL  2  90  20
+
+[ citation ]
+2023RAlessandri-Macromolecules
+polyply

--- a/polyply/data/ibi_GBNO2/citations.bib
+++ b/polyply/data/ibi_GBNO2/citations.bib
@@ -1,0 +1,22 @@
+
+@article{2023RAlessandri-Macromolecules,
+  title={Prediction of Electronic Properties of Radical-Containing Polymers at Coarse-Grained Resolutions},
+  author={Alessandri, Riccardo and de Pablo, Juan J},
+  journal={Macromolecules},
+  volume={56},
+  number={10},
+  pages={3574-3584},
+  doi={10.1021/acs.macromol.3c00141},
+  year={2023}
+}
+
+
+@article{polyply,
+  title={Polyply; a python suite for facilitating simulations of (bio-) macromolecules and nanomaterials},
+  author={Grunewald, Fabian and Alessandri, Riccardo and Kroon, Peter C and Monticelli, Luca and Souza, Paulo CT and Marrink, Siewert J},
+  journal={Nature Communications},
+  doi={10.1038/s41467-021-27627-4},
+  year={2022},
+  volume={13},
+  pages={68}
+}


### PR DESCRIPTION
This is the last model to be added from [2209.02072](https://arxiv.org/abs/2209.02072)/[10.1021/acs.macromol.3c00141](https://doi.org/10.1021/acs.macromol.3c00141). It is the CG model made via Iterative Boltzmann Inversion (IBI) CG model that uses the "GBNO2" mapping. Also for PTMA.

- [x] .ff; incl. link to zenodo via `[info]`
- [x] library.md
- [ ] test