### PR TITLE
Update citation of Martini 3 PTMA model

### DIFF
--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -21,7 +21,7 @@
 |Polystyrene sulfonate          |PSS                      |                                                                       |[martini2](polyply/data/martini2/PSS.martini.2.itp)   |
 |                               |                         |                                                                       |[martini3](polyply/data/martini3/PSS.martini3.ff)     |
 |Poly(para-phenylene ethynylene)|PPE                      |                                                                       |[martini3](polyply/data/martini3/PPE.martini3.ff)     |
-|Poly(TEMPO methacrylate)       |PTMA                     |[oplsaaLigParGen](polyply/data/oplsaaLigParGen/PTMA.oplsaa.LigParGen.ff)]|[martini3](polyply/data/martini3/PTMA.martini3.ff)  |
+|Poly(TEMPO methacrylate)       |PTMA                     |[oplsaaLigParGen](polyply/data/oplsaaLigParGen/PTMA.oplsaa.LigParGen.ff)|[martini3](polyply/data/martini3/PTMA.martini3.ff)   |
 |                               |                         |                                                                       |[ibi_cgm3](polyply/data/ibi_cmg3/PTMA.cgm3.ibi.ff)    |
 |                               |                         |                                                                       |[ibi_gbcg](polyply/data/ibi_gbcg/PTMA.gbno2.ibi.ff)   |
 |Dextran                        |DEX                      |                                                                       |[martini3](polyply/data/martini3/dextran.martini3.ff) |

--- a/polyply/data/martini3/PTMA.martini3.ff
+++ b/polyply/data/martini3/PTMA.martini3.ff
@@ -55,6 +55,6 @@ resname "PTMA"
 EST  VNL  +VNL  2  70  20
 
 [ citation ]
-2022RAlessandri-arXiv
+2023RAlessandri-Macromolecules
 Martini3
 polyply

--- a/polyply/data/martini3/citations.bib
+++ b/polyply/data/martini3/citations.bib
@@ -31,14 +31,16 @@ pages={382--388}
   publisher={The Royal Society of Chemistry},
   url={http://dx.doi.org/10.1039/D1CP04237H},
 }
-@article{2022RAlessandri-arXiv,
-  title={Predicting Electronic Properties of Radical-Containing Polymers at Coarse-Grained Resolutions},
-  author={Alessandri, Riccardo and de Pablo, Juan J.},
-  journal={arXiv},
-  year={2022},
-  eprint={2209.02072},
-  primaryClass={cond-mat.soft},
-  doi={https://doi.org/10.48550/arXiv.2209.02072}}
+@article{2023RAlessandri-Macromolecules,
+  title={Prediction of Electronic Properties of Radical-Containing Polymers at Coarse-Grained Resolutions},
+  author={Alessandri, Riccardo and de Pablo, Juan J},
+  journal={Macromolecules},
+  volume={56},
+  number={10},
+  pages={3574-3584},
+  doi={10.1021/acs.macromol.3c00141},
+  year={2023}
+}
 @article{M3_sugars,
   title={Martini 3 Coarse-Grained Force Field for Carbohydrates},
   author={Fabian, Grünewald and Mats H., Punt and Elizabeth E., Jefferys and Petteri A., Vainikka and Melanie, König and Valtteri, Virtanen and Travis A., Meyer and Weria, Pezeshkian and Adam J., Gormley and Maarit, Karonen and Mark S. P., Sansom and Paulo C. T, Souza and Siewert J., Marrink},


### PR DESCRIPTION
Update citation of Martini 3 PTMA model (from arxiv to Macromolecules paper). Also fixes a small formatting error in LIBRARY.md.