### PR TITLE
M3 aa posres fix

### DIFF
--- a/.github/workflows/pypi_deploy.yml
+++ b/.github/workflows/pypi_deploy.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Run pytest with codecoverage
       run:  pytest --cov polyply --cov-report=xml
     - name: Upload coverage codecov   
-      uses: codecov/codecov-action@v3 
+      uses: codecov/codecov-action@v4
       with:
             verbose: true
             token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Run pytest with codecoverage
       run:  pytest --cov polyply --cov-report=xml
     - name: Upload coverage codecov   
-      uses: codecov/codecov-action@v3 
+      uses: codecov/codecov-action@v4
       with:
             token: ${{ secrets.CODECOV_TOKEN }}
             files: ./coverage.xml

--- a/polyply/data/martini3/aminoacids.ff
+++ b/polyply/data/martini3/aminoacids.ff
@@ -38,8 +38,7 @@ GLY                1
  1   SP1   1     GLY    BB     1      0      
  2    VS   1     GLY    CA     1      0   0
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-[ virtual_sitesn ]
+1  1 1000 1000 1000 {"ifdef": "POSRES"}[ virtual_sitesn ]
 2 1 -- 1
 
 ;;; ALANINE
@@ -51,23 +50,22 @@ ALA                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
  1   SP2    1   ALA    BB     1      0
- 2   TC3    1   ALA    SC1    1      0 
+ 2   TC3    1   ALA    SC1    1      0
  3    VS    1   ALA    CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
 
 [ constraints ]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
   BB   SC1    1       0.270
 
 [ bonds ]
-#meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}   
-;  i     j   funct   length  
+#meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
+;  i     j   funct   length
 BB   SC1    1       0.270  $stiff_fc
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; CYSTEINE
 
 [ moleculetype ]
@@ -77,7 +75,7 @@ CYS                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
  1   $prot_default_bb_type     1   CYS    BB     1      0
- 2   TC6    1   CYS    SC1     1      0     
+ 2   TC6    1   CYS    SC1     1      0
  3    VS    1   CYS    CA      1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -85,10 +83,9 @@ CYS                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.341     7500        
+  BB   SC1    1       0.341     7500
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; VALINE
 
 [ moleculetype ]
@@ -97,25 +94,24 @@ VAL                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   SP2  1     VAL     BB     1      0    
- 2   SC3  1     VAL     SC1    1      0    
+ 1   SP2  1     VAL     BB     1      0
+ 2   SC3  1     VAL     SC1    1      0
  3    VS  1     VAL     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
 
 [ constraints ]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
   BB   SC1    1       0.292
 
 [ bonds ]
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
   BB   SC1    1       0.292  $stiff_fc
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; LEUCINE
 
 [ moleculetype ]
@@ -124,8 +120,8 @@ LEU                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type   1     LEU     BB     1      0    
- 2   SC2  1     LEU     SC1    1      0    
+ 1   $prot_default_bb_type   1     LEU     BB     1      0
+ 2   SC2  1     LEU     SC1    1      0
  3    VS  1     LEU     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -133,11 +129,10 @@ LEU                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.363     7500    
+  BB   SC1    1       0.363     7500
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; ISOLEUCINE
 
 [ moleculetype ]
@@ -146,25 +141,24 @@ ILE                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type   1     ILE     BB     1      0    
- 2   SC2  1     ILE     SC1    1      0    
+ 1   $prot_default_bb_type   1     ILE     BB     1      0
+ 2   SC2  1     ILE     SC1    1      0
  3    VS  1     ILE     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
 
 [ constraints ]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
   BB   SC1    1       0.341
 
 [ bonds ]
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
   BB   SC1    1       0.341  $stiff_fc
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; METHIONINE
 
 [ moleculetype ]
@@ -173,8 +167,8 @@ MET                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type   1     MET     BB     1      0    
- 2   C6   1     MET     SC1    1      0     
+ 1   $prot_default_bb_type   1     MET     BB     1      0
+ 2   C6   1     MET     SC1    1      0
  3    VS  1     MET     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -185,8 +179,7 @@ MET                1
   BB   SC1    1       0.40     2500
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; PROLINE
 
 [ moleculetype ]
@@ -195,8 +188,8 @@ PRO                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   SP2a   1     PRO     BB     1      0    
- 2   SC3    1     PRO     SC1    1      0    
+ 1   SP2a   1     PRO     BB     1      0
+ 2   SC3    1     PRO     SC1    1      0
  3    VS    1     PRO     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -208,16 +201,15 @@ PRO                1
   BB   SC1   1       0.330     7500
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 [ moleculetype ]
 ; molname       nrexcl
 HYP                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1    P1   1     HYP     BB     1      0    
- 2    P1   1     HYP     SC1    1      0    
+ 1    P1   1     HYP     BB     1      0
+ 2    P1   1     HYP     SC1    1      0
  3    VS   1     HYP     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -229,8 +221,7 @@ HYP                1
   BB   SC1   1       0.300     7500
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; ASPARAGINE
 
 [ moleculetype ]
@@ -239,8 +230,8 @@ ASN                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type    1     ASN     BB     1      0    
- 2   SP5    1     ASN     SC1    1      0    
+ 1   $prot_default_bb_type    1     ASN     BB     1      0
+ 2   SP5    1     ASN     SC1    1      0
  3    VS    1     ASN     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -251,8 +242,7 @@ ASN                1
   BB   SC1    1       0.352     5000
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; GLUTAMINE
 
 [ moleculetype ]
@@ -261,8 +251,8 @@ GLN                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type    1     GLN     BB     1      0    
- 2   P5     1     GLN     SC1    1      0    
+ 1   $prot_default_bb_type    1     GLN     BB     1      0
+ 2   P5     1     GLN     SC1    1      0
  3   VS     1     GLN     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -270,11 +260,10 @@ GLN                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.400    5000     
+  BB   SC1    1       0.400    5000
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; ASPARTATE
 
 [ moleculetype ]
@@ -283,8 +272,8 @@ ASP                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type     1     ASP     BB     1      0    
- 2   SQ5n    1     ASP     SC1    1   -1.0    
+ 1   $prot_default_bb_type     1     ASP     BB     1      0
+ 2   SQ5n    1     ASP     SC1    1   -1.0
  3   VS      1     ASP     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -295,8 +284,7 @@ ASP                1
   BB   SC1    1       0.352     7500
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; GLUTAMATE
 
 [ moleculetype ]
@@ -305,8 +293,8 @@ GLU                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type     1     GLU     BB     1      0    
- 2   Q5n    1     GLU     SC1    1   -1.0    
+ 1   $prot_default_bb_type     1     GLU     BB     1      0
+ 2   Q5n    1     GLU     SC1    1   -1.0
  3   VS     1     GLU     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -314,11 +302,10 @@ GLU                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.400    5000     
+  BB   SC1    1       0.400    5000
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; THREONINE
 
 [ moleculetype ]
@@ -327,8 +314,8 @@ THR                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
-1   $prot_default_bb_type     1     THR     BB     1      0    
-2   SP1     1     THR     SC1    1      0    
+1   $prot_default_bb_type     1     THR     BB     1      0
+2   SP1     1     THR     SC1    1      0
 3   VS      1     THR     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -340,12 +327,11 @@ THR                1
 
 [ bonds ]
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length 
+;  i     j   funct   length
   BB   SC1    1       0.305  $stiff_fc
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; SERINE
 
 [ moleculetype ]
@@ -354,8 +340,8 @@ SER                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
-1   $prot_default_bb_type     1    SER     BB     1      0    
-2   TP1     1    SER     SC1    1      0    
+1   $prot_default_bb_type     1    SER     BB     1      0
+2   TP1     1    SER     SC1    1      0
 3   VS      1    SER     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -366,9 +352,8 @@ SER                1
   BB   SC1    1       0.287     7500
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
-;;; LYSINE 
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
+;;; LYSINE
 
 [ moleculetype ]
 ; molname       nrexcl
@@ -376,9 +361,9 @@ LYS                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type    1     LYS     BB     1      0    
- 2   SC3    1     LYS     SC1    1      0    
- 3   SQ4p   1     LYS     SC2    1    1.0    
+ 1   $prot_default_bb_type    1     LYS     BB     1      0
+ 2   SC3    1     LYS     SC1    1      0
+ 3   SQ4p   1     LYS     SC2    1    1.0
  4   VS     1     LYS     CA     1      0   0
 [ virtual_sitesn ]
 4 1 -- 1
@@ -386,18 +371,17 @@ LYS                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.330     5000      
- SC1   SC2    1       0.360     5000  
+  BB   SC1    1       0.330     5000
+ SC1   SC2    1       0.360     5000
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-  BB   SC1  SC2       2   180.000    25.0      
+  BB   SC1  SC2       2   180.000    25.0
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
-;;; ARGININE 
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
+;;; ARGININE
 
 [ moleculetype ]
 ; molname       nrexcl
@@ -405,9 +389,9 @@ ARG                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
-1   $prot_default_bb_type     1     ARG     BB     1      0    
-2   SC3      1     ARG     SC1    1      0    
-3   SQ3p     1     ARG     SC2    1    1.0    
+1   $prot_default_bb_type     1     ARG     BB     1      0
+2   SC3      1     ARG     SC1    1      0
+3   SQ3p     1     ARG     SC2    1    1.0
 4   VS       1     ARG     CA     1      0   0
 [ virtual_sitesn ]
 4 1 -- 1
@@ -415,18 +399,17 @@ ARG                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.330     5000   
- SC1   SC2    1       0.380     5000  
+  BB   SC1    1       0.330     5000
+ SC1   SC2    1       0.380     5000
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-  BB   SC1  SC2       2   180.000    25.0      
+  BB   SC1  SC2       2   180.000    25.0
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
-;;; HISTIDINE 
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
+;;; HISTIDINE
 
 [ moleculetype ]
 ;molname       nrexcl
@@ -434,7 +417,7 @@ HIS                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
-1   $prot_default_bb_type     1     HIS     BB     1      0    
+1   $prot_default_bb_type     1     HIS     BB     1      0
 2   TC4     1     HIS     SC1    1    0    ; three side chains in triangle
 3   TN6d    1     HIS     SC2    1    0    ; configuration, mimicking
 4   TN5a    1     HIS     SC3    1    0    ; ring structure
@@ -445,25 +428,25 @@ HIS                1
 [ bonds ]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.336     7500 
+  BB   SC1    1       0.336     7500
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
  SC1   SC2    1       0.320  $stiff_fc
- SC1   SC3    1       0.300  $stiff_fc 
+ SC1   SC3    1       0.300  $stiff_fc
  SC2   SC3    1       0.270  $stiff_fc
 
 [ constraints ]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
  SC1   SC2    1       0.320
- SC1   SC3    1       0.300  
+ SC1   SC3    1       0.300
  SC2   SC3    1       0.270
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-   BB   SC1  SC2       2   120.000   50.0  
-   BB   SC1  SC3       2   120.000   50.0 
+   BB   SC1  SC2       2   120.000   50.0
+   BB   SC1  SC3       2   120.000   50.0
 
 ;[dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
@@ -476,21 +459,20 @@ SC1 SC2 SC3
 SC2 SC3
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 [ moleculetype ]
 ;molname       nrexcl
 HIH                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
-1   $prot_default_bb_type     1     HIS     BB     1      0    
+1   $prot_default_bb_type     1     HIS     BB     1      0
 2   TC4     1     HIH     SC1    2    0      ; three side chains in triangle
 3   TN6d    1     HIH     SC2    3    0      ; configuration, mimicking
 4   TQ2p    1     HIH     SC3    4    1      ; ring structure
-;2   TC4     1     HIH     SC1    2    0      ; three side chains in triangle 
+;2   TC4     1     HIH     SC1    2    0      ; three side chains in triangle
 ;3   TP3dq   1     HIH     SC2    3   +0.5    ; modelB
-;4   TP3dq   1     HIH     SC3    4   +0.5    ; 
+;4   TP3dq   1     HIH     SC3    4   +0.5    ;
 5   VS      1     HIH     CA     1      0   0
 [ virtual_sitesn ]
 5 1 -- 1
@@ -499,25 +481,25 @@ HIH                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.336     7500 
+  BB   SC1    1       0.336     7500
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
  SC1   SC2    1       0.320  $stiff_fc
- SC1   SC3    1       0.300  $stiff_fc 
+ SC1   SC3    1       0.300  $stiff_fc
  SC2   SC3    1       0.270  $stiff_fc
 
 [constraints]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
  SC1   SC2    1       0.320
- SC1   SC3    1       0.300  
+ SC1   SC3    1       0.300
  SC2   SC3    1       0.270
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-   BB   SC1  SC2       2   120.000   50.0  
-   BB   SC1  SC3       2   120.000   50.0 
+   BB   SC1  SC2       2   120.000   50.0
+   BB   SC1  SC3       2   120.000   50.0
 
 ;[dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
@@ -530,8 +512,7 @@ SC1 SC2 SC3
 SC2 SC3
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; PHENYLALANINE
 
 [ moleculetype ]
@@ -551,16 +532,16 @@ PHE                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.325     7500 	
+  BB   SC1    1       0.325     7500
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
  SC1   SC2    1       0.340  $stiff_fc
  SC1   SC3    1       0.340  $stiff_fc
  SC2   SC3    1       0.290  $stiff_fc
 
 [constraints]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
  SC1   SC2    1       0.340
  SC1   SC3    1       0.340
  SC2   SC3    1       0.290
@@ -568,8 +549,8 @@ PHE                1
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-  BB   SC1  SC2        2   120.000   50.0  
-  BB   SC1  SC3        2   120.000   50.0 
+  BB   SC1  SC2        2   120.000   50.0
+  BB   SC1  SC3        2   120.000   50.0
 
 ;[dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
@@ -582,8 +563,7 @@ SC1 SC2 SC3
 SC2 SC3
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; TYROSINE
 
 [ moleculetype ]
@@ -593,9 +573,9 @@ TYR                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
 1   $prot_default_bb_type     1     TYR     BB     1    0
-2   TC4    1     TYR     SC1    1    0  
-3   TC5    1     TYR     SC2    1    0 
-4   TC5    1     TYR     SC3    1    0  
+2   TC4    1     TYR     SC1    1    0
+3   TC5    1     TYR     SC2    1    0
+4   TC5    1     TYR     SC3    1    0
 5   TN6    1     TYR     SC4    1    0
 6   VS     1     TYR     CA     1      0   0
 [ virtual_sitesn ]
@@ -605,9 +585,9 @@ TYR                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.325    5000 	
+  BB   SC1    1       0.325    5000
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
  SC1   SC2    1       0.300  $stiff_fc
  SC1   SC3    1       0.300  $stiff_fc
  SC2   SC4    1       0.285  $stiff_fc
@@ -616,7 +596,7 @@ TYR                1
 
 [constraints]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
  SC1   SC2    1       0.300
  SC1   SC3    1       0.300
  SC2   SC4    1       0.285
@@ -626,8 +606,8 @@ TYR                1
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-   BB   SC1  SC2       2   120.000   60.0  
-   BB   SC1  SC3       2   120.000   60.0 
+   BB   SC1  SC2       2   120.000   60.0
+   BB   SC1  SC3       2   120.000   60.0
 
 [dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
@@ -641,8 +621,7 @@ SC2 SC3 SC4
 SC3 SC4
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; TRYPTOPHAN
 
 [ moleculetype ]
@@ -662,9 +641,9 @@ TRP                1
 [ bonds ]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.315     5000 	
+  BB   SC1    1       0.315     5000
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
  SC1   SC2    1       0.335  $stiff_fc
  SC2   SC5    1       0.412  $stiff_fc
  SC4   SC5    1       0.293  $stiff_fc
@@ -673,7 +652,7 @@ TRP                1
 
 [ constraints ]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length  
+;  i     j   funct   length
  SC1   SC2    1       0.335
  SC2   SC5    1       0.412
  SC4   SC5    1       0.293
@@ -683,8 +662,8 @@ TRP                1
 [ angles ]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-  BB   SC1  SC2       2   120.000   60.0 
-  BB   SC1  SC4       2   130.000    60.0  
+  BB   SC1  SC2       2   120.000   60.0
+  BB   SC1  SC4       2   130.000    60.0
 
 [ dihedrals ]
 ;  i     j    k    l   funct   angle  force.c.
@@ -707,8 +686,7 @@ SC3 SC4 SC5
 SC4 SC5
 
 [ position_restraints ]
-1  1  1 1000 1000 1000 {"ifdef": "POSRES"}
-
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
 ;;; Links
 
 ;; Links for COIL. We apply them first as coil is the default.

--- a/polyply/data/martini3/aminoacids.ff
+++ b/polyply/data/martini3/aminoacids.ff
@@ -38,7 +38,8 @@ GLY                1
  1   SP1   1     GLY    BB     1      0      
  2    VS   1     GLY    CA     1      0   0
 [ position_restraints ]
-1  1 1000 1000 1000 {"ifdef": "POSRES"}[ virtual_sitesn ]
+1  1 1000 1000 1000 {"ifdef": "POSRES"}
+[ virtual_sitesn ]
 2 1 -- 1
 
 ;;; ALANINE
@@ -50,22 +51,23 @@ ALA                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
  1   SP2    1   ALA    BB     1      0
- 2   TC3    1   ALA    SC1    1      0
+ 2   TC3    1   ALA    SC1    1      0 
  3    VS    1   ALA    CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
 
 [ constraints ]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
   BB   SC1    1       0.270
 
 [ bonds ]
-#meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length
+#meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}   
+;  i     j   funct   length  
 BB   SC1    1       0.270  $stiff_fc
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; CYSTEINE
 
 [ moleculetype ]
@@ -75,7 +77,7 @@ CYS                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
  1   $prot_default_bb_type     1   CYS    BB     1      0
- 2   TC6    1   CYS    SC1     1      0
+ 2   TC6    1   CYS    SC1     1      0     
  3    VS    1   CYS    CA      1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -83,9 +85,10 @@ CYS                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.341     7500
+  BB   SC1    1       0.341     7500        
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; VALINE
 
 [ moleculetype ]
@@ -94,24 +97,25 @@ VAL                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   SP2  1     VAL     BB     1      0
- 2   SC3  1     VAL     SC1    1      0
+ 1   SP2  1     VAL     BB     1      0    
+ 2   SC3  1     VAL     SC1    1      0    
  3    VS  1     VAL     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
 
 [ constraints ]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
   BB   SC1    1       0.292
 
 [ bonds ]
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
   BB   SC1    1       0.292  $stiff_fc
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; LEUCINE
 
 [ moleculetype ]
@@ -120,8 +124,8 @@ LEU                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type   1     LEU     BB     1      0
- 2   SC2  1     LEU     SC1    1      0
+ 1   $prot_default_bb_type   1     LEU     BB     1      0    
+ 2   SC2  1     LEU     SC1    1      0    
  3    VS  1     LEU     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -129,10 +133,11 @@ LEU                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.363     7500
+  BB   SC1    1       0.363     7500    
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; ISOLEUCINE
 
 [ moleculetype ]
@@ -141,24 +146,25 @@ ILE                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type   1     ILE     BB     1      0
- 2   SC2  1     ILE     SC1    1      0
+ 1   $prot_default_bb_type   1     ILE     BB     1      0    
+ 2   SC2  1     ILE     SC1    1      0    
  3    VS  1     ILE     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
 
 [ constraints ]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
   BB   SC1    1       0.341
 
 [ bonds ]
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
   BB   SC1    1       0.341  $stiff_fc
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; METHIONINE
 
 [ moleculetype ]
@@ -167,8 +173,8 @@ MET                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type   1     MET     BB     1      0
- 2   C6   1     MET     SC1    1      0
+ 1   $prot_default_bb_type   1     MET     BB     1      0    
+ 2   C6   1     MET     SC1    1      0     
  3    VS  1     MET     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -180,6 +186,7 @@ MET                1
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; PROLINE
 
 [ moleculetype ]
@@ -188,8 +195,8 @@ PRO                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   SP2a   1     PRO     BB     1      0
- 2   SC3    1     PRO     SC1    1      0
+ 1   SP2a   1     PRO     BB     1      0    
+ 2   SC3    1     PRO     SC1    1      0    
  3    VS    1     PRO     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -202,14 +209,15 @@ PRO                1
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 [ moleculetype ]
 ; molname       nrexcl
 HYP                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1    P1   1     HYP     BB     1      0
- 2    P1   1     HYP     SC1    1      0
+ 1    P1   1     HYP     BB     1      0    
+ 2    P1   1     HYP     SC1    1      0    
  3    VS   1     HYP     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -222,6 +230,7 @@ HYP                1
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; ASPARAGINE
 
 [ moleculetype ]
@@ -230,8 +239,8 @@ ASN                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type    1     ASN     BB     1      0
- 2   SP5    1     ASN     SC1    1      0
+ 1   $prot_default_bb_type    1     ASN     BB     1      0    
+ 2   SP5    1     ASN     SC1    1      0    
  3    VS    1     ASN     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -243,6 +252,7 @@ ASN                1
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; GLUTAMINE
 
 [ moleculetype ]
@@ -251,8 +261,8 @@ GLN                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type    1     GLN     BB     1      0
- 2   P5     1     GLN     SC1    1      0
+ 1   $prot_default_bb_type    1     GLN     BB     1      0    
+ 2   P5     1     GLN     SC1    1      0    
  3   VS     1     GLN     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -260,10 +270,11 @@ GLN                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.400    5000
+  BB   SC1    1       0.400    5000     
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; ASPARTATE
 
 [ moleculetype ]
@@ -272,8 +283,8 @@ ASP                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type     1     ASP     BB     1      0
- 2   SQ5n    1     ASP     SC1    1   -1.0
+ 1   $prot_default_bb_type     1     ASP     BB     1      0    
+ 2   SQ5n    1     ASP     SC1    1   -1.0    
  3   VS      1     ASP     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -285,6 +296,7 @@ ASP                1
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; GLUTAMATE
 
 [ moleculetype ]
@@ -293,8 +305,8 @@ GLU                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type     1     GLU     BB     1      0
- 2   Q5n    1     GLU     SC1    1   -1.0
+ 1   $prot_default_bb_type     1     GLU     BB     1      0    
+ 2   Q5n    1     GLU     SC1    1   -1.0    
  3   VS     1     GLU     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -302,10 +314,11 @@ GLU                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.400    5000
+  BB   SC1    1       0.400    5000     
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; THREONINE
 
 [ moleculetype ]
@@ -314,8 +327,8 @@ THR                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
-1   $prot_default_bb_type     1     THR     BB     1      0
-2   SP1     1     THR     SC1    1      0
+1   $prot_default_bb_type     1     THR     BB     1      0    
+2   SP1     1     THR     SC1    1      0    
 3   VS      1     THR     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -327,11 +340,12 @@ THR                1
 
 [ bonds ]
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length 
   BB   SC1    1       0.305  $stiff_fc
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; SERINE
 
 [ moleculetype ]
@@ -340,8 +354,8 @@ SER                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
-1   $prot_default_bb_type     1    SER     BB     1      0
-2   TP1     1    SER     SC1    1      0
+1   $prot_default_bb_type     1    SER     BB     1      0    
+2   TP1     1    SER     SC1    1      0    
 3   VS      1    SER     CA     1      0   0
 [ virtual_sitesn ]
 3 1 -- 1
@@ -353,7 +367,8 @@ SER                1
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
-;;; LYSINE
+
+;;; LYSINE 
 
 [ moleculetype ]
 ; molname       nrexcl
@@ -361,9 +376,9 @@ LYS                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   $prot_default_bb_type    1     LYS     BB     1      0
- 2   SC3    1     LYS     SC1    1      0
- 3   SQ4p   1     LYS     SC2    1    1.0
+ 1   $prot_default_bb_type    1     LYS     BB     1      0    
+ 2   SC3    1     LYS     SC1    1      0    
+ 3   SQ4p   1     LYS     SC2    1    1.0    
  4   VS     1     LYS     CA     1      0   0
 [ virtual_sitesn ]
 4 1 -- 1
@@ -371,17 +386,18 @@ LYS                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.330     5000
- SC1   SC2    1       0.360     5000
+  BB   SC1    1       0.330     5000      
+ SC1   SC2    1       0.360     5000  
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-  BB   SC1  SC2       2   180.000    25.0
+  BB   SC1  SC2       2   180.000    25.0      
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
-;;; ARGININE
+
+;;; ARGININE 
 
 [ moleculetype ]
 ; molname       nrexcl
@@ -389,9 +405,9 @@ ARG                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
-1   $prot_default_bb_type     1     ARG     BB     1      0
-2   SC3      1     ARG     SC1    1      0
-3   SQ3p     1     ARG     SC2    1    1.0
+1   $prot_default_bb_type     1     ARG     BB     1      0    
+2   SC3      1     ARG     SC1    1      0    
+3   SQ3p     1     ARG     SC2    1    1.0    
 4   VS       1     ARG     CA     1      0   0
 [ virtual_sitesn ]
 4 1 -- 1
@@ -399,17 +415,18 @@ ARG                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.330     5000
- SC1   SC2    1       0.380     5000
+  BB   SC1    1       0.330     5000   
+ SC1   SC2    1       0.380     5000  
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-  BB   SC1  SC2       2   180.000    25.0
+  BB   SC1  SC2       2   180.000    25.0      
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
-;;; HISTIDINE
+
+;;; HISTIDINE 
 
 [ moleculetype ]
 ;molname       nrexcl
@@ -417,7 +434,7 @@ HIS                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
-1   $prot_default_bb_type     1     HIS     BB     1      0
+1   $prot_default_bb_type     1     HIS     BB     1      0    
 2   TC4     1     HIS     SC1    1    0    ; three side chains in triangle
 3   TN6d    1     HIS     SC2    1    0    ; configuration, mimicking
 4   TN5a    1     HIS     SC3    1    0    ; ring structure
@@ -428,25 +445,25 @@ HIS                1
 [ bonds ]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.336     7500
+  BB   SC1    1       0.336     7500 
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
  SC1   SC2    1       0.320  $stiff_fc
- SC1   SC3    1       0.300  $stiff_fc
+ SC1   SC3    1       0.300  $stiff_fc 
  SC2   SC3    1       0.270  $stiff_fc
 
 [ constraints ]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
  SC1   SC2    1       0.320
- SC1   SC3    1       0.300
+ SC1   SC3    1       0.300  
  SC2   SC3    1       0.270
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-   BB   SC1  SC2       2   120.000   50.0
-   BB   SC1  SC3       2   120.000   50.0
+   BB   SC1  SC2       2   120.000   50.0  
+   BB   SC1  SC3       2   120.000   50.0 
 
 ;[dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
@@ -460,19 +477,20 @@ SC2 SC3
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 [ moleculetype ]
 ;molname       nrexcl
 HIH                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
-1   $prot_default_bb_type     1     HIS     BB     1      0
+1   $prot_default_bb_type     1     HIS     BB     1      0    
 2   TC4     1     HIH     SC1    2    0      ; three side chains in triangle
 3   TN6d    1     HIH     SC2    3    0      ; configuration, mimicking
 4   TQ2p    1     HIH     SC3    4    1      ; ring structure
-;2   TC4     1     HIH     SC1    2    0      ; three side chains in triangle
+;2   TC4     1     HIH     SC1    2    0      ; three side chains in triangle 
 ;3   TP3dq   1     HIH     SC2    3   +0.5    ; modelB
-;4   TP3dq   1     HIH     SC3    4   +0.5    ;
+;4   TP3dq   1     HIH     SC3    4   +0.5    ; 
 5   VS      1     HIH     CA     1      0   0
 [ virtual_sitesn ]
 5 1 -- 1
@@ -481,25 +499,25 @@ HIH                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.336     7500
+  BB   SC1    1       0.336     7500 
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
  SC1   SC2    1       0.320  $stiff_fc
- SC1   SC3    1       0.300  $stiff_fc
+ SC1   SC3    1       0.300  $stiff_fc 
  SC2   SC3    1       0.270  $stiff_fc
 
 [constraints]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
  SC1   SC2    1       0.320
- SC1   SC3    1       0.300
+ SC1   SC3    1       0.300  
  SC2   SC3    1       0.270
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-   BB   SC1  SC2       2   120.000   50.0
-   BB   SC1  SC3       2   120.000   50.0
+   BB   SC1  SC2       2   120.000   50.0  
+   BB   SC1  SC3       2   120.000   50.0 
 
 ;[dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
@@ -513,6 +531,7 @@ SC2 SC3
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; PHENYLALANINE
 
 [ moleculetype ]
@@ -532,16 +551,16 @@ PHE                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.325     7500
+  BB   SC1    1       0.325     7500 	
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
  SC1   SC2    1       0.340  $stiff_fc
  SC1   SC3    1       0.340  $stiff_fc
  SC2   SC3    1       0.290  $stiff_fc
 
 [constraints]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
  SC1   SC2    1       0.340
  SC1   SC3    1       0.340
  SC2   SC3    1       0.290
@@ -549,8 +568,8 @@ PHE                1
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-  BB   SC1  SC2        2   120.000   50.0
-  BB   SC1  SC3        2   120.000   50.0
+  BB   SC1  SC2        2   120.000   50.0  
+  BB   SC1  SC3        2   120.000   50.0 
 
 ;[dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
@@ -564,6 +583,7 @@ SC2 SC3
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; TYROSINE
 
 [ moleculetype ]
@@ -573,9 +593,9 @@ TYR                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
 1   $prot_default_bb_type     1     TYR     BB     1    0
-2   TC4    1     TYR     SC1    1    0
-3   TC5    1     TYR     SC2    1    0
-4   TC5    1     TYR     SC3    1    0
+2   TC4    1     TYR     SC1    1    0  
+3   TC5    1     TYR     SC2    1    0 
+4   TC5    1     TYR     SC3    1    0  
 5   TN6    1     TYR     SC4    1    0
 6   VS     1     TYR     CA     1      0   0
 [ virtual_sitesn ]
@@ -585,9 +605,9 @@ TYR                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.325    5000
+  BB   SC1    1       0.325    5000 	
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
  SC1   SC2    1       0.300  $stiff_fc
  SC1   SC3    1       0.300  $stiff_fc
  SC2   SC4    1       0.285  $stiff_fc
@@ -596,7 +616,7 @@ TYR                1
 
 [constraints]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
  SC1   SC2    1       0.300
  SC1   SC3    1       0.300
  SC2   SC4    1       0.285
@@ -606,8 +626,8 @@ TYR                1
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-   BB   SC1  SC2       2   120.000   60.0
-   BB   SC1  SC3       2   120.000   60.0
+   BB   SC1  SC2       2   120.000   60.0  
+   BB   SC1  SC3       2   120.000   60.0 
 
 [dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
@@ -622,6 +642,7 @@ SC3 SC4
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; TRYPTOPHAN
 
 [ moleculetype ]
@@ -641,9 +662,9 @@ TRP                1
 [ bonds ]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  BB   SC1    1       0.315     5000
+  BB   SC1    1       0.315     5000 	
 #meta {"group": "Side chain bonds", "ifdef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
  SC1   SC2    1       0.335  $stiff_fc
  SC2   SC5    1       0.412  $stiff_fc
  SC4   SC5    1       0.293  $stiff_fc
@@ -652,7 +673,7 @@ TRP                1
 
 [ constraints ]
 #meta {"group": "Side chain bonds", "ifndef": "FLEXIBLE"}
-;  i     j   funct   length
+;  i     j   funct   length  
  SC1   SC2    1       0.335
  SC2   SC5    1       0.412
  SC4   SC5    1       0.293
@@ -662,8 +683,8 @@ TRP                1
 [ angles ]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-  BB   SC1  SC2       2   120.000   60.0
-  BB   SC1  SC4       2   130.000    60.0
+  BB   SC1  SC2       2   120.000   60.0 
+  BB   SC1  SC4       2   130.000    60.0  
 
 [ dihedrals ]
 ;  i     j    k    l   funct   angle  force.c.
@@ -687,6 +708,7 @@ SC4 SC5
 
 [ position_restraints ]
 1  1 1000 1000 1000 {"ifdef": "POSRES"}
+
 ;;; Links
 
 ;; Links for COIL. We apply them first as coil is the default.


### PR DESCRIPTION
position restraint directives had too many parameters for each amino acid which caused problems on grompp