### PR TITLE
Fix/380

### DIFF
--- a/polyply/src/build_file_parser.py
+++ b/polyply/src/build_file_parser.py
@@ -152,6 +152,7 @@ class BuildDirector(SectionLineParser):
         node_name, atype = tokens[0], tokens[1]
         position = np.array(tokens[2:], dtype=float)
         self.current_template.add_node(node_name,
+                                       atomname=node_name,
                                        atype=atype,
                                        position=position)
 
@@ -200,14 +201,16 @@ class BuildDirector(SectionLineParser):
             # if the volume is not defined yet compute the volume, this still
             # can be overwritten by an explicit volume directive later
             resname = self.current_template.name
-            if resname not in self.topology.volumes:
-                self.topology.volumes[resname] = compute_volume(self.current_template,
-                                                                coords,
-                                                                self.topology.nonbond_params,)
+            graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(self.current_template,
+                                                                                  node_attr='atomname')
+            if graph_hash not in self.topology.volumes:
+                self.topology.volumes[graph_hash] = compute_volume(self.current_template,
+                                                                   coords,
+                                                                   self.topology.nonbond_params,)
             # internally a template is defined as vectors from the
             # center of geometry
             mapped_coords = map_from_CoG(coords)
-            self.templates[resname] = mapped_coords
+            self.templates[graph_hash] = mapped_coords
             self.current_template = None
 
     def finalize(self, lineno=0):

--- a/polyply/src/check_residue_equivalence.py
+++ b/polyply/src/check_residue_equivalence.py
@@ -62,10 +62,10 @@ def group_residues_by_hash(meta_molecule, template_graphs={}):
     dict[`:class:nx.Graph`]
         keys are the hash of the graph
     """
-    unique_graphs = {}
-    for graph in template_graphs.values():
-        graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')
-        unique_graphs[graph_hash] = graph
+    unique_graphs = template_graphs
+#    for graph in template_graphs.values():
+#        graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')
+#        unique_graphs[graph_hash] = graph
 
     for node in meta_molecule.nodes:
         graph = meta_molecule.nodes[node]["graph"]

--- a/polyply/src/check_residue_equivalence.py
+++ b/polyply/src/check_residue_equivalence.py
@@ -63,10 +63,6 @@ def group_residues_by_hash(meta_molecule, template_graphs={}):
         keys are the hash of the graph
     """
     unique_graphs = template_graphs
-#    for graph in template_graphs.values():
-#        graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')
-#        unique_graphs[graph_hash] = graph
-
     for node in meta_molecule.nodes:
         graph = meta_molecule.nodes[node]["graph"]
         graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')

--- a/polyply/src/generate_templates.py
+++ b/polyply/src/generate_templates.py
@@ -337,8 +337,8 @@ class GenerateTemplates(Processor):
         self.templates
         self.volumes
         """
-        for resname, template_graph in tqdm(template_graphs.items()):
-            if resname not in self.templates:
+        for graph_hash, template_graph in tqdm(template_graphs.items()):
+            if graph_hash not in self.templates:
                 block = extract_block(meta_molecule.molecule,
                                       template_graph,
                                       self.topology.defines)
@@ -364,13 +364,15 @@ class GenerateTemplates(Processor):
                         break
                     else:
                         opt_counter += 1
-
-                if resname not in self.volumes:
-                    self.volumes[resname] = compute_volume(block,
+                resname = block.nodes[list(block.nodes)[0]]['resname']
+                if resname in self.volumes:
+                    self.volumes[graph_hash] = self.volumes[resname]
+                else:
+                    self.volumes[graph_hash] = compute_volume(block,
                                                            coords,
                                                            self.topology.nonbond_params)
                 coords = map_from_CoG(coords)
-                self.templates[resname] = coords
+                self.templates[graph_hash] = coords
 
     def run_molecule(self, meta_molecule):
         """

--- a/polyply/src/generate_templates.py
+++ b/polyply/src/generate_templates.py
@@ -36,6 +36,7 @@ def _extract_template_graphs(meta_molecule, template_graphs={}, skip_filter=Fals
             resname = meta_molecule.nodes[node]["resname"]
             graph = meta_molecule.nodes[node]["graph"]
             graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')
+            meta_molecule.nodes[node]["template"] = graph_hash
             if resname in template_graphs:
                 template_graphs[graph_hash] = graph
                 del template_graphs[resname]

--- a/polyply/src/generate_templates.py
+++ b/polyply/src/generate_templates.py
@@ -22,7 +22,6 @@ from .linalg_functions import (u_vect, center_of_geometry,
 from .topology import replace_defined_interaction
 from .linalg_functions import dih
 from .check_residue_equivalence import group_residues_by_hash
-from tqdm import tqdm
 """
 Processor generating coordinates for all residues of a meta_molecule
 matching those in the meta_molecule.molecule attribute.
@@ -337,7 +336,7 @@ class GenerateTemplates(Processor):
         self.templates
         self.volumes
         """
-        for graph_hash, template_graph in tqdm(template_graphs.items()):
+        for graph_hash, template_graph in template_graphs.items():
             if graph_hash not in self.templates:
                 block = extract_block(meta_molecule.molecule,
                                       template_graph,

--- a/polyply/tests/test_generate_templates.py
+++ b/polyply/tests/test_generate_templates.py
@@ -153,14 +153,22 @@ class TestGenTemps:
              len(ff.blocks["GLY"].interactions[inter_type]) == len(new_block.interactions[inter_type])
 
       @staticmethod
-      def test_run_molecule():
+      @pytest.mark.parametrize('volumes', (
+                               None,
+                               {"PMMA": 0.55},
+      ))
+      def test_run_molecule(volumes):
           top = polyply.src.topology.Topology.from_gmx_topfile(TEST_DATA / "topology_test" / "system.top", "test")
           top.gen_pairs()
+          if volumes:
+            top.volumes = volumes
           top.convert_nonbond_to_sig_eps()
           GenerateTemplates(topology=top, skip_filter=False, max_opt=10).run_molecule(top.molecules[0])
           graph = top.molecules[0].nodes[0]['graph']
           graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')
           assert graph_hash in top.volumes
+          if volumes:
+            assert top.volumes[graph_hash] == volumes['PMMA']
           assert graph_hash in top.molecules[0].templates
 
       @staticmethod

--- a/polyply/tests/test_generate_templates.py
+++ b/polyply/tests/test_generate_templates.py
@@ -342,3 +342,7 @@ def test_extract_template_graphs(example_meta_molecule, resnames, gen_template_g
         graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')
         templated = list(nx.get_node_attributes(unique_graphs[graph_hash], 'template').values())
         assert all(templated)
+
+    # assert that all nodes have the template attribute
+    for node in example_meta_molecule.nodes:
+        assert example_meta_molecule.nodes[node].get('template', False)

--- a/polyply/tests/test_generate_templates.py
+++ b/polyply/tests/test_generate_templates.py
@@ -330,18 +330,14 @@ def test_extract_template_graphs(example_meta_molecule, resnames, gen_template_g
     for node in gen_template_graphs:
         graph = example_meta_molecule.nodes[node]['graph']
         nx.set_node_attributes(graph, True, 'template')
-        template_graphs[example_meta_molecule.nodes[node]['resname']] = graph
+        graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')
+        template_graphs[graph_hash] = None
 
     # perfrom the grouping
     unique_graphs = _extract_template_graphs(example_meta_molecule, template_graphs, skip_filter)
 
     # check the outcome
     assert len(unique_graphs) == 2
-
-    for graph in template_graphs.values():
-        graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')
-        templated = list(nx.get_node_attributes(unique_graphs[graph_hash], 'template').values())
-        assert all(templated)
 
     # assert that all nodes have the template attribute
     for node in example_meta_molecule.nodes:

--- a/polyply/tests/test_residue_equivalence.py
+++ b/polyply/tests/test_residue_equivalence.py
@@ -28,8 +28,9 @@ def test_group_by_hash(example_meta_molecule, resnames, gen_template_graphs):
     template_graphs = {}
     for node in gen_template_graphs:
         graph = example_meta_molecule.nodes[node]['graph']
+        graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')
         nx.set_node_attributes(graph, True, 'template')
-        template_graphs[example_meta_molecule.nodes[node]['resname']] = graph
+        template_graphs[graph_hash] = graph
 
     # perfrom the grouping
     unique_graphs = group_residues_by_hash(example_meta_molecule, template_graphs)
@@ -37,8 +38,7 @@ def test_group_by_hash(example_meta_molecule, resnames, gen_template_graphs):
     # check the outcome
     assert len(unique_graphs) == 2
 
-    for graph in template_graphs.values():
-        graph_hash = nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(graph, node_attr='atomname')
+    for graph_hash in template_graphs:
         templated = list(nx.get_node_attributes(unique_graphs[graph_hash], 'template').values())
         assert all(templated)
 


### PR DESCRIPTION
fixes some issues with the graph hashing that occur when using templates. There was a conflict between using graph hashes or residue names as keys for the volumes and templates. With this PR we use graph_hashes in all cases. The only dodgy thing is that internally in GenerateTemplates templates are first graphs then the coordinate dicts. This will be fixed with the new template backmapping scheme anyway. 