### PR TITLE
change in record level

### DIFF
--- a/polyply/src/apply_modifications.py
+++ b/polyply/src/apply_modifications.py
@@ -32,8 +32,8 @@ def _patch_protein_termini(meta_molecule, ter_mods=['N-ter', 'C-ter']):
         protein_termini.append(last_mod)
     else:
         # if only one mod in ter_mods, apply the mod to both start and end residue
-        LOGGER.info("Only one terminal modification specified. "
-                    f"Will apply {ter_mods[0]} to both {meta_molecule.nodes[0]['resname']}1 and {last_resname}{max_resid}")
+        LOGGER.warning("Only one terminal modification specified. "
+                      f"Will apply {ter_mods[0]} to both {meta_molecule.nodes[0]['resname']}1 and {last_resname}{max_resid}")
         protein_termini.append(({'resid': max_resid, 'resname': last_resname}, ter_mods[0]))
 
     return protein_termini
@@ -60,7 +60,7 @@ def apply_mod(meta_molecule, modifications):
     molecule = meta_molecule.molecule
 
     if not molecule.force_field.modifications:
-        LOGGER.warning('No modifications present in forcefield, none will be applied')
+        LOGGER.info('No modifications present in forcefield, none will be applied')
         return meta_molecule
 
     for target, desired_mod in modifications:
@@ -77,13 +77,14 @@ def apply_mod(meta_molecule, modifications):
         target_residue = meta_molecule.nodes[target_resid - 1]
         # takes care to skip all residues that come from an itp file
         if not target_residue.get('from_itp', 'False'):
-            LOGGER.warning("meta_molecule has come from itp. Will not attempt to modify.")
+            LOGGER.info("meta_molecule has come from itp. Will not attempt to modify.")
             continue
+
         # checks that the resname is a protein resname as defined above
         if not vermouth.molecule.attributes_match(target_residue,
                                               {'resname': vermouth.molecule.Choice(protein_resnames.split("|"))}):
-            LOGGER.warning("The resname of your target residue is not recognised a protein resname. "
-                           "Will not attempt to modify.")
+            LOGGER.info("The resname of your target residue is not recognised a protein resname. "
+                        "Will not attempt to modify.")
             continue
 
         anum_dict = {}
@@ -121,6 +122,5 @@ class ApplyModifications(Processor):
             self.target_mods = _patch_protein_termini(meta_molecule)
 
     def run_molecule(self, meta_molecule):
-
         apply_mod(meta_molecule, self.target_mods)
         return meta_molecule

--- a/polyply/tests/test_apply_modifications.py
+++ b/polyply/tests/test_apply_modifications.py
@@ -75,20 +75,25 @@ def test_mods_in_ff(caplog, ff_files, expected):
     with expected:
         assert len(ff.modifications) > 0
 
-@pytest.mark.parametrize('input_itp, molname, expected',
+@pytest.mark.parametrize('input_itp, molname, expected, text',
                          (
     (
     'ALA5.itp',
     'pALA',
-    False),
+    False,
+    None),
     ('PEO.itp',
      'PEO',
-    True)
-                         ))
-def test_apply_mod(input_itp, molname, expected, caplog):
+    True,
+    ("The resname of your target residue"
+     " is not recognised a protein resname. "
+     "Will not attempt to modify."))
+))
+def test_apply_mod(caplog, input_itp, molname, expected, text):
     """
     test that modifications get applied correctly
     """
+    caplog.set_level(logging.INFO)
     #make the meta molecule from the itp and ff files
     file_name = TEST_DATA / "itp" / input_itp
 
@@ -107,7 +112,12 @@ def test_apply_mod(input_itp, molname, expected, caplog):
     apply_mod(meta_mol, termini)
 
     if expected:
-        assert any(rec.levelname == 'WARNING' for rec in caplog.records)
+        for record in caplog.records:
+            if record.message == text:
+                assert True
+                break
+        else:
+            assert False
 
     else:
         #for each mod applied, check that the mod atom and interactions have been changed correctly
@@ -134,25 +144,32 @@ def test_apply_mod(input_itp, molname, expected, caplog):
                                                        meta=interaction.meta)
                             assert _interaction in meta_mol.molecule.interactions[interaction_type]
 
-@pytest.mark.parametrize('modifications, expected',
+@pytest.mark.parametrize('modifications, expected, text',
      (
              (
                  [['A1', 'N-ter']],
-                 True
+                 True,
+                 None
              ),
 
              (
                  [],
-                 True
+                 True,
+                 "No modifications present in forcefield, none will be applied"
              ),
 
      ))
-def test_ApplyModifications(example_meta_molecule, caplog, modifications, expected):
-
+def test_ApplyModifications(example_meta_molecule, caplog, modifications, expected, text):
+    caplog.set_level(logging.INFO)
 
     ApplyModifications(modifications=modifications,
                        meta_molecule=example_meta_molecule).run_molecule(example_meta_molecule)
 
     if expected:
-        assert any(rec.levelname == 'WARNING' for rec in caplog.records)
-
+        for record in caplog.records:
+            if record.message == text:
+                assert True
+                break
+        else:
+            assert False
+        assert any(rec.levelname == 'INFO' for rec in caplog.records)


### PR DESCRIPTION
this PR changes the record level regarding the modifications. It is a bit excessive that a warning is issued for the cases when we get expected default behavior. 

@csbrasnett there is one broken test: In the last test the modification 'A1' is provided. It was tested to give a warning. However, the warning was an incorrect one. I think the A1 should actually raise an error or a different warning. 

Besides that I think we are missing a warning for the case when a protein residue is given but no modifications. 