### PR TITLE
Extra aa code

### DIFF
--- a/polyply/src/simple_seq_parsers.py
+++ b/polyply/src/simple_seq_parsers.py
@@ -51,6 +51,7 @@ ONE_LETTER_AA = {"G": "GLY",
                  "H": "HIS",
                  "D": "ASP",
                  "E": "GLU",
+                 "O": "HYP"
                  }
 
 class FileFormatError(Exception):


### PR DESCRIPTION
Noticed we were missing the one letter code for HYP in the fasta parsing.

Once we fix #384 hopefully we can move the other AA modifications over to the modifications.ff file for the martini3 data for more consistency (and to actually be able to use them in polyply) (I will try to fix the modifications next week)