### PR TITLE
implement patch for nx versions > 3.5

### DIFF
--- a/polyply/src/simple_seq_parsers.py
+++ b/polyply/src/simple_seq_parsers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from collections import (namedtuple, OrderedDict)
 from functools import partial
+from packaging.version import Version
 import json
 import networkx as nx
 from networkx.readwrite import json_graph
@@ -335,6 +336,12 @@ def parse_json(filepath):
     with open(filepath) as file_:
         data = json.load(file_)
 
+    # the format of node_link_graph has changed in version 3.6
+    # instead of link the edges now need to have the keyword
+    # edges
+    old_edges = data.get("links", None)
+    if old_edges and Version(nx.__version__) > Version('3.5'):
+        data["edges"] = old_edges
     init_json_graph = nx.Graph(json_graph.node_link_graph(data))
     # the nodes in the inital graph are not ordered, when no resid
     # is given this can create issues. So we reorder the node based

--- a/polyply/tests/test_data/gen_seq/ref/PEO_PS_ref.json
+++ b/polyply/tests/test_data/gen_seq/ref/PEO_PS_ref.json
@@ -114,7 +114,7 @@
       "id": 21
     }
   ],
-  "links": [
+  "edges": [
     {
       "source": 0,
       "target": 1

--- a/polyply/tests/test_data/gen_seq/ref/PPI_ref.json
+++ b/polyply/tests/test_data/gen_seq/ref/PPI_ref.json
@@ -74,7 +74,7 @@
       "id": 13
     }
   ],
-  "links": [
+  "edges": [
     {
       "source": 0,
       "target": 1

--- a/polyply/tests/test_data/gen_seq/ref/lyso_PEG.json
+++ b/polyply/tests/test_data/gen_seq/ref/lyso_PEG.json
@@ -674,7 +674,7 @@
       "id": 133
     }
   ],
-  "links": [
+  "edges": [
     {
       "source": 0,
       "target": 1

--- a/polyply/tests/test_gen_seq.py
+++ b/polyply/tests/test_gen_seq.py
@@ -219,8 +219,6 @@ def test_gen_seq(tmp_path,
 
     with open(outpath) as _file:
         js_graph = json.load(_file)
-        if Version(nx.__version__) < Version('3.6'):
-            js_graph["links"] = js_graph["edges"]
         out_graph = json_graph.node_link_graph(js_graph)
 
     assert nx.is_isomorphic(out_graph, ref_graph)

--- a/polyply/tests/test_gen_seq.py
+++ b/polyply/tests/test_gen_seq.py
@@ -213,13 +213,13 @@ def test_gen_seq(tmp_path,
 
     with open(ref_file) as _file:
         js_graph = json.load(_file)
-        if Version(nx.__version__) < Version(3.6):
+        if Version(nx.__version__) < Version('3.6'):
             js_graph["lins"] == js_graph["edges"]
         ref_graph = json_graph.node_link_graph(js_graph)
 
     with open(outpath) as _file:
         js_graph = json.load(_file)
-        if Version(nx.__version__) < Version(3.6):
+        if Version(nx.__version__) < Version('3.6'):
             js_graph["lins"] == js_graph["edges"]
         out_graph = json_graph.node_link_graph(js_graph)
 

--- a/polyply/tests/test_gen_seq.py
+++ b/polyply/tests/test_gen_seq.py
@@ -214,13 +214,13 @@ def test_gen_seq(tmp_path,
     with open(ref_file) as _file:
         js_graph = json.load(_file)
         if Version(nx.__version__) < Version('3.6'):
-            js_graph["lins"] == js_graph["edges"]
+            js_graph["links"] == js_graph["edges"]
         ref_graph = json_graph.node_link_graph(js_graph)
 
     with open(outpath) as _file:
         js_graph = json.load(_file)
         if Version(nx.__version__) < Version('3.6'):
-            js_graph["lins"] == js_graph["edges"]
+            js_graph["links"] == js_graph["edges"]
         out_graph = json_graph.node_link_graph(js_graph)
 
     assert nx.is_isomorphic(out_graph, ref_graph)

--- a/polyply/tests/test_gen_seq.py
+++ b/polyply/tests/test_gen_seq.py
@@ -214,13 +214,13 @@ def test_gen_seq(tmp_path,
     with open(ref_file) as _file:
         js_graph = json.load(_file)
         if Version(nx.__version__) < Version('3.6'):
-            js_graph["links"] == js_graph["edges"]
+            js_graph["links"] = js_graph["edges"]
         ref_graph = json_graph.node_link_graph(js_graph)
 
     with open(outpath) as _file:
         js_graph = json.load(_file)
         if Version(nx.__version__) < Version('3.6'):
-            js_graph["links"] == js_graph["edges"]
+            js_graph["links"] = js_graph["edges"]
         out_graph = json_graph.node_link_graph(js_graph)
 
     assert nx.is_isomorphic(out_graph, ref_graph)

--- a/polyply/tests/test_gen_seq.py
+++ b/polyply/tests/test_gen_seq.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from packaging.version import Version
 import json
 from pathlib import Path
 import networkx as nx
@@ -212,10 +213,14 @@ def test_gen_seq(tmp_path,
 
     with open(ref_file) as _file:
         js_graph = json.load(_file)
+        if Version(nx.__version__) < Version(3.6):
+            js_graph["lins"] == js_graph["edges"]
         ref_graph = json_graph.node_link_graph(js_graph)
 
     with open(outpath) as _file:
         js_graph = json.load(_file)
+        if Version(nx.__version__) < Version(3.6):
+            js_graph["lins"] == js_graph["edges"]
         out_graph = json_graph.node_link_graph(js_graph)
 
     assert nx.is_isomorphic(out_graph, ref_graph)


### PR DESCRIPTION
Since NX 3.6, the JSON graph format has changed. Edges are now declared using the edges attribute instead of the previous links. Since we do not care, this fix will copy links to edges. 