### PR TITLE
PLGA Martini2 parameters

### DIFF
--- a/polyply/data/martini2/PLGA_M2.ff
+++ b/polyply/data/martini2/PLGA_M2.ff
@@ -1,0 +1,222 @@
+[ citations ]
+Martini2
+M2_PLGA
+
+; =============================================================================
+; PLGA (poly(lactic-co-glycolic acid)) Martini 2 / polyply .ff parameter file
+;
+; Based on the supporting information of:
+; "A coarse-grained molecular dynamics description of docetaxel-conjugate release
+;  from PLGA matrices" (Pannuzzo et al.), Figure S1 (bond/angle/dihedral targets).
+;
+; This file defines PLGA monomers as *single-bead* residues so that polyply can
+; build arbitrary LA/GA sequences (like the Martini2 DNA .ff pattern).
+;
+; Published parameters explicitly available in the SI:
+;   Bonds:
+;     XL–YG   b0=0.377 nm  k=25000 kJ/mol/nm^2
+;     YG–XL   b0=0.352 nm  k=25000 kJ/mol/nm^2
+;   Angles:
+;     XL–YG–XL  theta0=133.5 deg  k=30 kJ/mol
+;     YG–XL–YG  theta0=109.0 deg  k=50 kJ/mol
+;   Proper dihedrals are reported for stereochemical variants (XLL/XLD) in Fig S1;
+;   encoding 4-residue dihedrals may require '++' atom addressing, which is not
+;   used in the provided DNA example. An *optional* (commented) dihedral block is
+;   therefore included at the end for users to test.
+;
+;   Use with MARTINI2.2
+; =============================================================================
+
+; -----------------------------------------------------------------------------;
+; Residues (single bead each)
+; -----------------------------------------------------------------------------;
+
+[ moleculetype ]
+LA 1
+[ atoms ]
+1 Na 1 LA BB 1 0.0 72.0
+
+[ moleculetype ]
+GA 1
+[ atoms ]
+1 Na 1 GA BB 1 0.0 72.0
+
+[ moleculetype ]
+LAL 1
+[ atoms ]
+1 Na 1 LAL BB 1 0.0 72.0
+
+[ moleculetype ]
+LAD 1
+[ atoms ]
+1 Na 1 LAD BB 1 0.0 72.0
+
+
+[ moleculetype ]
+ESTter 1
+[ atoms ]
+1 P1 1 ESTter TE 1 0.0 72.0
+
+[ moleculetype ]
+ACIDter 1
+[ atoms ]
+1 P3 1 ACIDter TA 1 0.0 72.0
+
+; Optional: hydroxyl termination (matches the residue name you used: OHter).
+; Keeping this here makes LA/GA - OHter sequences connected.
+[ moleculetype ]
+OHter 1
+[ atoms ]
+1 SP2 1 OHter OH 1 0.0 45.0
+
+; -----------------------------------------------------------------------------;
+; Links (inter-residue connectivity)
+; -----------------------------------------------------------------------------;
+
+; LA -> GA bond (XL–YG)
+[ link ]
+[ atoms ]
+BB  { "resname": "LA|LAL|LAD" }
++BB { "resname": "GA" }
+[ bonds ]
+BB +BB 1 0.37700 25000 {"group": "backbone"}
+[ edges ]
+BB +BB
+
+; GA -> LA bond (YG–XL)
+[ link ]
+[ atoms ]
+BB  { "resname": "GA" }
++BB { "resname": "LA|LAL|LAD" }
+[ bonds ]
+BB +BB 1 0.35200 25000 {"group": "backbone"}
+[ edges ]
+BB +BB
+
+; Fallback bond for same-type neighbors or other combinations (not reported in SI)
+; Chosen as the average of the two published lengths (0.377 and 0.352 nm).
+[ link ]
+[ atoms ]
+BB  { "resname": "LA|GA|LAL|LAD" }
++BB { "resname": "LA|GA|LAL|LAD" }
+[ bonds ]
+BB +BB 1 0.36450 25000 {"group": "backbone_fallback"}
+[ edges ]
+BB +BB
+
+; -----------------------------------------------------------------------------;
+; Termination links (make end beads connected)
+; -----------------------------------------------------------------------------;
+
+; Any monomer -> hydroxyl terminus
+[ link ]
+[ atoms ]
+BB  { "resname": "LA|GA|LAL|LAD" }
++OH { "resname": "OHter" }
+[ bonds ]
+BB +OH 1 0.36450 25000 {"group": "terminal"}
+[ edges ]
+BB +OH
+
+; Any monomer -> ester terminus
+[ link ]
+[ atoms ]
+BB  { "resname": "LA|GA|LAL|LAD" }
++TE { "resname": "ESTter" }
+[ bonds ]
+BB +TE 1 0.36450 25000 {"group": "terminal"}
+[ edges ]
+BB +TE
+
+; Any monomer -> acid terminus
+[ link ]
+[ atoms ]
+BB  { "resname": "LA|GA|LAL|LAD" }
++TA { "resname": "ACIDter" }
+[ bonds ]
+BB +TA 1 0.36450 25000 {"group": "terminal"}
+[ edges ]
+BB +TA
+
+; -----------------------------------------------------------------------------;
+; Angles spanning three consecutive monomers
+; -----------------------------------------------------------------------------;
+
+; XL–YG–XL  (LA–GA–LA)
+[ link ]
+[ atoms ]
+-BB { "resname": "LA|LAL|LAD" }
+BB  { "resname": "GA" }
++BB { "resname": "LA|LAL|LAD" }
+[ angles ]
+-BB BB +BB 2 133.50000 30.0 {"group": "backbone"}
+[ edges ]
+-BB BB
+BB +BB
+
+; YG–XL–YG  (GA–LA–GA)
+[ link ]
+[ atoms ]
+-BB { "resname": "GA" }
+BB  { "resname": "LA|LAL|LAD" }
++BB { "resname": "GA" }
+[ angles ]
+-BB BB +BB 2 109.00000 50.0 {"group": "backbone"}
+[ edges ]
+-BB BB
+BB +BB
+
+; Fallback angle (not reported in SI)
+[ link ]
+[ atoms ]
+-BB { "resname": "LA|GA|LAL|LAD" }
+BB  { "resname": "LA|GA|LAL|LAD" }
++BB { "resname": "LA|GA|LAL|LAD" }
+[ angles ]
+-BB BB +BB 2 120.00000 25.0 {"group": "backbone_fallback"}
+[ edges ]
+-BB BB
+BB +BB
+
+; -----------------------------------------------------------------------------;
+; Terminal angles (NOT reported in SI; pragmatic defaults)
+; These only affect the last three beads (...-monomer-monomer-terminus)
+; -----------------------------------------------------------------------------;
+
+; ... BB - BB - OHter
+[ link ]
+[ atoms ]
+-BB { "resname": "LA|GA|LAL|LAD" }
+BB  { "resname": "LA|GA|LAL|LAD" }
++OH { "resname": "OHter" }
+[ angles ]
+-BB BB +OH 2 120.00000 25.0 {"group": "terminal"}
+[ edges ]
+-BB BB
+BB +OH
+
+; ... BB - BB - ESTter
+[ link ]
+[ atoms ]
+-BB { "resname": "LA|GA|LAL|LAD" }
+BB  { "resname": "LA|GA|LAL|LAD" }
++TE { "resname": "ESTter" }
+[ angles ]
+-BB BB +TE 2 120.00000 25.0 {"group": "terminal"}
+[ edges ]
+-BB BB
+BB +TE
+
+; ... BB - BB - ACIDter
+[ link ]
+[ atoms ]
+-BB { "resname": "LA|GA|LAL|LAD" }
+BB  { "resname": "LA|GA|LAL|LAD" }
++TA { "resname": "ACIDter" }
+[ angles ]
+-BB BB +TA 2 120.00000 25.0 {"group": "terminal"}
+[ edges ]
+-BB BB
+BB +TA
+
+

--- a/polyply/data/martini2/PLGA_M2.ff
+++ b/polyply/data/martini2/PLGA_M2.ff
@@ -1,12 +1,16 @@
+;--------------------------------------------------
+; PLGA vermouth force field fragment for polyply
+; Parameters from Pannuzzo et al. Biomacromolecules 2022
+; For use with MARTINI 2.2 / Martini2 library in polyply.
+;--------------------------------------------------
+
 [ citations ]
 Martini2
 M2_PLGA
 
-;---------------------------
-;   Parameters from https://pubs.acs.org/doi/10.1021/acs.biomac.2c00903
-;   Use with MARTINI2.2
-
+;==================================================
 ; Residues (single bead each)
+;==================================================
 
 [ moleculetype ]
 LA 1
@@ -19,19 +23,21 @@ GA 1
 1 Na 1 GA BB 1 0.0 72.0
 
 [ moleculetype ]
-LAL 1
+LAL 1 ; L-Lactic acid
 [ atoms ]
 1 Na 1 LAL BB 1 0.0 72.0
 
 [ moleculetype ]
-LAD 1
+LAD 1 ; D-Lactic acid
 [ atoms ]
 1 Na 1 LAD BB 1 0.0 72.0
 
-;------------------------------------------
-; Links (inter-residue connectivity)
 
-; LA -> GA bond (XL–YG)
+;==================================================
+; SPECIFIC BACKBONE BONDS
+;==================================================
+
+; LA/LAL/LAD -> GA  (X–Y)
 [ link ]
 [ atoms ]
 BB  { "resname": "LA|LAL|LAD" }
@@ -41,7 +47,7 @@ BB +BB 1 0.37700 25000 {"group": "backbone"}
 [ edges ]
 BB +BB
 
-; GA -> LA bond (YG–XL)
+; GA -> LA/LAL/LAD  (Y–X)
 [ link ]
 [ atoms ]
 BB  { "resname": "GA" }
@@ -51,21 +57,12 @@ BB +BB 1 0.35200 25000 {"group": "backbone"}
 [ edges ]
 BB +BB
 
-; Fallback bond for same-type neighbors or other combinations (not reported in SI but validated)
-; Chosen as the average of the two published lengths (0.377 and 0.352 nm).
-[ link ]
-[ atoms ]
-BB  { "resname": "LA|GA|LAL|LAD" }
-+BB { "resname": "LA|GA|LAL|LAD" }
-[ bonds ]
-BB +BB 1 0.36450 25000 {"group": "backbone_fallback"}
-[ edges ]
-BB +BB
 
-;--------------------------------------------------
-; Angles spanning three consecutive monomers
+;==================================================
+; SPECIFIC BACKBONE ANGLES
+;==================================================
 
-; XL–YG–XL  (LA–GA–LA)
+; X–Y–X  (LA-family–GA–LA-family)
 [ link ]
 [ atoms ]
 -BB { "resname": "LA|LAL|LAD" }
@@ -77,7 +74,7 @@ BB  { "resname": "GA" }
 -BB BB
 BB +BB
 
-; YG–XL–YG  (GA–LA–GA)
+; Y–X–Y  (GA–LA-family–GA)
 [ link ]
 [ atoms ]
 -BB { "resname": "GA" }
@@ -89,12 +86,162 @@ BB  { "resname": "LA|LAL|LAD" }
 -BB BB
 BB +BB
 
-; Fallback angle (not reported in SI but validated)
+
+;==================================================
+; SPECIFIC BACKBONE DIHEDRALS
+;==================================================
+
+;--------------------------------------------------
+; LAD–GA–LAL–GA
+; From paper: -70 (2.21)
+;--------------------------------------------------
 [ link ]
 [ atoms ]
--BB { "resname": "LA|GA|LAL|LAD" }
-BB  { "resname": "LA|GA|LAL|LAD" }
-+BB { "resname": "LA|GA|LAL|LAD" }
+-BB  { "resname": "LAD" }
+BB   { "resname": "GA" }
++BB  { "resname": "LAL" }
+++BB { "resname": "GA" }
+[ dihedrals ]
+-BB BB +BB ++BB  1  -70.0   2.21   1 {"group": "backbone"}
+[ edges ]
+-BB BB
+BB +BB
++BB ++BB
+
+;--------------------------------------------------
+; GA-LAL-GA-LAD
+; From paper: 130.0 (0.5)
+;--------------------------------------------------
+
+[ link ]
+[ atoms ]
+-BB  { "resname": "GA" }
+BB   { "resname": "LAL" }
++BB  { "resname": "GA" }
+++BB { "resname": "LAD" }
+[ dihedrals ]
+-BB BB +BB ++BB  1  130.0   0.5   1 {"group": "backbone"}
+[ edges ]
+-BB BB
+BB +BB
++BB ++BB
+
+;--------------------------------------------------
+; LAL–GA–LAD–GA
+; From paper: 70 (2.21)
+;--------------------------------------------------
+[ link ]
+[ atoms ]
+-BB  { "resname": "LAL" }
+BB   { "resname": "GA" }
++BB  { "resname": "LAD" }
+++BB { "resname": "GA" }
+[ dihedrals ]
+-BB BB +BB ++BB  1   70.0   2.21   1 {"group": "backbone"}
+[ edges ]
+-BB BB
+BB +BB
++BB ++BB
+
+
+;--------------------------------------------------
+; GA–LAD–GA–LAL
+; From paper: -130 (0.52), 180 (0.51, 0.23) [and implied 70 (2.21) not listed here]
+;--------------------------------------------------
+[ link ]
+[ atoms ]
+-BB  { "resname": "GA" }
+BB   { "resname": "LAD" }
++BB  { "resname": "GA" }
+++BB { "resname": "LAL" }
+[ dihedrals ]
+-BB BB +BB ++BB  1  -130.0  0.52   1 {"group": "backbone"}
+[ edges ]
+-BB BB
+BB +BB
++BB ++BB
+
+
+;==================================================
+; Keep generic alternating dihedrals for LA/GA when LA is not
+; split into LAL/LAD (e.g., sequences using "LA" only which will be recognised by polyply).
+;==================================================
+
+; LA-family–GA–LA-family–GA (generic)
+[ link ]
+[ atoms ]
+-BB  { "resname": "LA" }
+BB   { "resname": "GA" }
++BB  { "resname": "LA" }
+++BB { "resname": "GA" }
+[ dihedrals ]
+-BB BB +BB ++BB  1  -70.0   2.21   1 {"group": "backbone"}
+[ edges ]
+-BB BB
+BB +BB
++BB ++BB
+
+; GA–LA-family–GA–LA-family (generic)
+[ link ]
+[ atoms ]
+-BB  { "resname": "GA" }
+BB   { "resname": "LA" }
++BB  { "resname": "GA" }
+++BB { "resname": "LA" }
+[ dihedrals ]
+-BB BB +BB ++BB  1   70.0   2.21   1 {"group": "backbone"}
+[ edges ]
+-BB BB
+BB +BB
++BB ++BB
+
+
+;==================================================
+; FALLBACK INTERACTIONS
+; (ONLY identical neighbors – will NOT override X–GA)
+;==================================================
+
+;----------------------------------
+; Fallback bonds (LA-family–LA-family, GA–GA)
+
+[ link ]
+[ atoms ]
+BB  { "resname": "LA|LAL|LAD" }
++BB { "resname": "LA|LAL|LAD" }
+[ bonds ]
+BB +BB 1 0.36450 25000 {"group": "backbone_fallback"}
+[ edges ]
+BB +BB
+
+[ link ]
+[ atoms ]
+BB  { "resname": "GA" }
++BB { "resname": "GA" }
+[ bonds ]
+BB +BB 1 0.36450 25000 {"group": "backbone_fallback"}
+[ edges ]
+BB +BB
+
+
+;----------------------------------
+; Fallback angles (LA-family–LA-family–LA-family, GA–GA–GA)
+
+[ link ]
+[ atoms ]
+-BB { "resname": "LA|LAL|LAD" }
+BB  { "resname": "LA|LAL|LAD" }
++BB { "resname": "LA|LAL|LAD" }
+[ angles ]
+-BB BB +BB 2 120.00000 25.0 {"group": "backbone_fallback"}
+[ edges ]
+-BB BB
+BB +BB
+
+[ link ]
+[ atoms ]
+-BB { "resname": "GA" }
+BB  { "resname": "GA" }
++BB { "resname": "GA" }
 [ angles ]
 -BB BB +BB 2 120.00000 25.0 {"group": "backbone_fallback"}
 [ edges ]
@@ -102,4 +249,31 @@ BB  { "resname": "LA|GA|LAL|LAD" }
 BB +BB
 
 
+;----------------------------------
+; Fallback dihedral (identical residues only)
 
+[ link ]
+[ atoms ]
+-BB  { "resname": "LA|LAL|LAD" }
+BB   { "resname": "LA|LAL|LAD" }
++BB  { "resname": "LA|LAL|LAD" }
+++BB { "resname": "LA|LAL|LAD" }
+[ dihedrals ]
+-BB BB +BB ++BB  1  180.0  1.0  1 {"group": "backbone_fallback"}
+[ edges ]
+-BB BB
+BB +BB
++BB ++BB
+
+[ link ]
+[ atoms ]
+-BB  { "resname": "GA" }
+BB   { "resname": "GA" }
++BB  { "resname": "GA" }
+++BB { "resname": "GA" }
+[ dihedrals ]
+-BB BB +BB ++BB  1  180.0  1.0  1 {"group": "backbone_fallback"}
+[ edges ]
+-BB BB
+BB +BB
++BB ++BB

--- a/polyply/data/martini2/PLGA_M2.ff
+++ b/polyply/data/martini2/PLGA_M2.ff
@@ -8,9 +8,9 @@
 Martini2
 M2_PLGA
 
-;==================================================
-; Residues (single bead each)
-;==================================================
+;--------------------------------------------------
+; Residues (single Na bead each)
+;--------------------------------------------------
 
 [ moleculetype ]
 LA 1
@@ -33,9 +33,9 @@ LAD 1 ; D-Lactic acid
 1 Na 1 LAD BB 1 0.0 72.0
 
 
-;==================================================
+;--------------------------------------------------
 ; SPECIFIC BACKBONE BONDS
-;==================================================
+;--------------------------------------------------
 
 ; LA/LAL/LAD -> GA  (X–Y)
 [ link ]
@@ -58,9 +58,9 @@ BB +BB 1 0.35200 25000 {"group": "backbone"}
 BB +BB
 
 
-;==================================================
+;--------------------------------------------------
 ; SPECIFIC BACKBONE ANGLES
-;==================================================
+;--------------------------------------------------
 
 ; X–Y–X  (LA-family–GA–LA-family)
 [ link ]
@@ -87,9 +87,9 @@ BB  { "resname": "LA|LAL|LAD" }
 BB +BB
 
 
-;==================================================
+;--------------------------------------------------
 ; SPECIFIC BACKBONE DIHEDRALS
-;==================================================
+;--------------------------------------------------
 
 ;--------------------------------------------------
 ; LAD–GA–LAL–GA
@@ -162,10 +162,10 @@ BB +BB
 +BB ++BB
 
 
-;==================================================
+;--------------------------------------------------
 ; Keep generic alternating dihedrals for LA/GA when LA is not
 ; split into LAL/LAD (e.g., sequences using "LA" only which will be recognised by polyply).
-;==================================================
+;--------------------------------------------------
 
 ; LA-family–GA–LA-family–GA (generic)
 [ link ]
@@ -196,10 +196,12 @@ BB +BB
 +BB ++BB
 
 
-;==================================================
+;--------------------------------------------------
 ; FALLBACK INTERACTIONS
 ; (ONLY identical neighbors – will NOT override X–GA)
-;==================================================
+; Not ideal but no other parameters provided in paper. A point for improvement
+; Generally taken average of bond lengths/120deg for angles and 180deg for dihedral
+;--------------------------------------------------
 
 ;----------------------------------
 ; Fallback bonds (LA-family–LA-family, GA–GA)
@@ -250,7 +252,8 @@ BB +BB
 
 
 ;----------------------------------
-; Fallback dihedral (identical residues only)
+; Fallback dihedral (identical residues only - defaults to 180)
+
 
 [ link ]
 [ atoms ]

--- a/polyply/data/martini2/PLGA_M2.ff
+++ b/polyply/data/martini2/PLGA_M2.ff
@@ -2,34 +2,11 @@
 Martini2
 M2_PLGA
 
-; =============================================================================
-; PLGA (poly(lactic-co-glycolic acid)) Martini 2 / polyply .ff parameter file
-;
-; Based on the supporting information of:
-; "A coarse-grained molecular dynamics description of docetaxel-conjugate release
-;  from PLGA matrices" (Pannuzzo et al.), Figure S1 (bond/angle/dihedral targets).
-;
-; This file defines PLGA monomers as *single-bead* residues so that polyply can
-; build arbitrary LA/GA sequences (like the Martini2 DNA .ff pattern).
-;
-; Published parameters explicitly available in the SI:
-;   Bonds:
-;     XL–YG   b0=0.377 nm  k=25000 kJ/mol/nm^2
-;     YG–XL   b0=0.352 nm  k=25000 kJ/mol/nm^2
-;   Angles:
-;     XL–YG–XL  theta0=133.5 deg  k=30 kJ/mol
-;     YG–XL–YG  theta0=109.0 deg  k=50 kJ/mol
-;   Proper dihedrals are reported for stereochemical variants (XLL/XLD) in Fig S1;
-;   encoding 4-residue dihedrals may require '++' atom addressing, which is not
-;   used in the provided DNA example. An *optional* (commented) dihedral block is
-;   therefore included at the end for users to test.
-;
+;---------------------------
+;   Parameters from https://pubs.acs.org/doi/10.1021/acs.biomac.2c00903
 ;   Use with MARTINI2.2
-; =============================================================================
 
-; -----------------------------------------------------------------------------;
 ; Residues (single bead each)
-; -----------------------------------------------------------------------------;
 
 [ moleculetype ]
 LA 1
@@ -51,27 +28,8 @@ LAD 1
 [ atoms ]
 1 Na 1 LAD BB 1 0.0 72.0
 
-
-[ moleculetype ]
-ESTter 1
-[ atoms ]
-1 P1 1 ESTter TE 1 0.0 72.0
-
-[ moleculetype ]
-ACIDter 1
-[ atoms ]
-1 P3 1 ACIDter TA 1 0.0 72.0
-
-; Optional: hydroxyl termination (matches the residue name you used: OHter).
-; Keeping this here makes LA/GA - OHter sequences connected.
-[ moleculetype ]
-OHter 1
-[ atoms ]
-1 SP2 1 OHter OH 1 0.0 45.0
-
-; -----------------------------------------------------------------------------;
+;------------------------------------------
 ; Links (inter-residue connectivity)
-; -----------------------------------------------------------------------------;
 
 ; LA -> GA bond (XL–YG)
 [ link ]
@@ -93,7 +51,7 @@ BB +BB 1 0.35200 25000 {"group": "backbone"}
 [ edges ]
 BB +BB
 
-; Fallback bond for same-type neighbors or other combinations (not reported in SI)
+; Fallback bond for same-type neighbors or other combinations (not reported in SI but validated)
 ; Chosen as the average of the two published lengths (0.377 and 0.352 nm).
 [ link ]
 [ atoms ]
@@ -104,43 +62,8 @@ BB +BB 1 0.36450 25000 {"group": "backbone_fallback"}
 [ edges ]
 BB +BB
 
-; -----------------------------------------------------------------------------;
-; Termination links (make end beads connected)
-; -----------------------------------------------------------------------------;
-
-; Any monomer -> hydroxyl terminus
-[ link ]
-[ atoms ]
-BB  { "resname": "LA|GA|LAL|LAD" }
-+OH { "resname": "OHter" }
-[ bonds ]
-BB +OH 1 0.36450 25000 {"group": "terminal"}
-[ edges ]
-BB +OH
-
-; Any monomer -> ester terminus
-[ link ]
-[ atoms ]
-BB  { "resname": "LA|GA|LAL|LAD" }
-+TE { "resname": "ESTter" }
-[ bonds ]
-BB +TE 1 0.36450 25000 {"group": "terminal"}
-[ edges ]
-BB +TE
-
-; Any monomer -> acid terminus
-[ link ]
-[ atoms ]
-BB  { "resname": "LA|GA|LAL|LAD" }
-+TA { "resname": "ACIDter" }
-[ bonds ]
-BB +TA 1 0.36450 25000 {"group": "terminal"}
-[ edges ]
-BB +TA
-
-; -----------------------------------------------------------------------------;
+;--------------------------------------------------
 ; Angles spanning three consecutive monomers
-; -----------------------------------------------------------------------------;
 
 ; XL–YG–XL  (LA–GA–LA)
 [ link ]
@@ -166,7 +89,7 @@ BB  { "resname": "LA|LAL|LAD" }
 -BB BB
 BB +BB
 
-; Fallback angle (not reported in SI)
+; Fallback angle (not reported in SI but validated)
 [ link ]
 [ atoms ]
 -BB { "resname": "LA|GA|LAL|LAD" }
@@ -178,45 +101,5 @@ BB  { "resname": "LA|GA|LAL|LAD" }
 -BB BB
 BB +BB
 
-; -----------------------------------------------------------------------------;
-; Terminal angles (NOT reported in SI; pragmatic defaults)
-; These only affect the last three beads (...-monomer-monomer-terminus)
-; -----------------------------------------------------------------------------;
-
-; ... BB - BB - OHter
-[ link ]
-[ atoms ]
--BB { "resname": "LA|GA|LAL|LAD" }
-BB  { "resname": "LA|GA|LAL|LAD" }
-+OH { "resname": "OHter" }
-[ angles ]
--BB BB +OH 2 120.00000 25.0 {"group": "terminal"}
-[ edges ]
--BB BB
-BB +OH
-
-; ... BB - BB - ESTter
-[ link ]
-[ atoms ]
--BB { "resname": "LA|GA|LAL|LAD" }
-BB  { "resname": "LA|GA|LAL|LAD" }
-+TE { "resname": "ESTter" }
-[ angles ]
--BB BB +TE 2 120.00000 25.0 {"group": "terminal"}
-[ edges ]
--BB BB
-BB +TE
-
-; ... BB - BB - ACIDter
-[ link ]
-[ atoms ]
--BB { "resname": "LA|GA|LAL|LAD" }
-BB  { "resname": "LA|GA|LAL|LAD" }
-+TA { "resname": "ACIDter" }
-[ angles ]
--BB BB +TA 2 120.00000 25.0 {"group": "terminal"}
-[ edges ]
--BB BB
-BB +TA
 
 

--- a/polyply/data/martini2/PLGA_M2.ff
+++ b/polyply/data/martini2/PLGA_M2.ff
@@ -93,7 +93,7 @@ BB +BB
 
 ;--------------------------------------------------
 ; LAD–GA–LAL–GA
-; From paper: -70 (2.21)
+; From paper: -70 (2.2)
 ;--------------------------------------------------
 [ link ]
 [ atoms ]
@@ -102,11 +102,13 @@ BB   { "resname": "GA" }
 +BB  { "resname": "LAL" }
 ++BB { "resname": "GA" }
 [ dihedrals ]
--BB BB +BB ++BB  1  -70.0   2.21   1 {"group": "backbone"}
+-BB BB +BB ++BB  1  -70.0   2.2   1 {"group": "backbone"}
 [ edges ]
 -BB BB
 BB +BB
 +BB ++BB
+
+
 
 ;--------------------------------------------------
 ; GA-LAL-GA-LAD
@@ -128,7 +130,7 @@ BB +BB
 
 ;--------------------------------------------------
 ; LAL–GA–LAD–GA
-; From paper: 70 (2.21)
+; From paper: 70 (2.2)
 ;--------------------------------------------------
 [ link ]
 [ atoms ]
@@ -137,7 +139,7 @@ BB   { "resname": "GA" }
 +BB  { "resname": "LAD" }
 ++BB { "resname": "GA" }
 [ dihedrals ]
--BB BB +BB ++BB  1   70.0   2.21   1 {"group": "backbone"}
+-BB BB +BB ++BB  1   70.0   2.2   1 {"group": "backbone"}
 [ edges ]
 -BB BB
 BB +BB
@@ -146,7 +148,7 @@ BB +BB
 
 ;--------------------------------------------------
 ; GA–LAD–GA–LAL
-; From paper: -130 (0.52), 180 (0.51, 0.23) [and implied 70 (2.21) not listed here]
+; From paper: -130 (0.5), 180 (0.5, 0.2) [and implied 70 (2.2) not listed here]
 ;--------------------------------------------------
 [ link ]
 [ atoms ]
@@ -155,7 +157,7 @@ BB   { "resname": "LAD" }
 +BB  { "resname": "GA" }
 ++BB { "resname": "LAL" }
 [ dihedrals ]
--BB BB +BB ++BB  1  -130.0  0.52   1 {"group": "backbone"}
+-BB BB +BB ++BB  1  -130.0  0.5   1 {"group": "backbone"}
 [ edges ]
 -BB BB
 BB +BB
@@ -175,7 +177,7 @@ BB   { "resname": "GA" }
 +BB  { "resname": "LA" }
 ++BB { "resname": "GA" }
 [ dihedrals ]
--BB BB +BB ++BB  1  -70.0   2.21   1 {"group": "backbone"}
+-BB BB +BB ++BB  1  -70.0   2.2   1 {"group": "backbone"}
 [ edges ]
 -BB BB
 BB +BB
@@ -189,7 +191,7 @@ BB   { "resname": "LA" }
 +BB  { "resname": "GA" }
 ++BB { "resname": "LA" }
 [ dihedrals ]
--BB BB +BB ++BB  1   70.0   2.21   1 {"group": "backbone"}
+-BB BB +BB ++BB  1   70.0   2.2   1 {"group": "backbone"}
 [ edges ]
 -BB BB
 BB +BB
@@ -214,6 +216,8 @@ BB  { "resname": "LA|LAL|LAD" }
 BB +BB 1 0.36450 25000 {"group": "backbone_fallback"}
 [ edges ]
 BB +BB
+[ warning ]
+This force field is derived from Pannuzzo et al. Biomacromolecules 2022. Some parameters are not optimized and are fallback values. Fallback parameters are labelled in the .itp files. Use with caution and verify results carefully.
 
 [ link ]
 [ atoms ]
@@ -223,6 +227,8 @@ BB  { "resname": "GA" }
 BB +BB 1 0.36450 25000 {"group": "backbone_fallback"}
 [ edges ]
 BB +BB
+[ warning ]
+This force field is derived from Pannuzzo et al. Biomacromolecules 2022. Some parameters are not optimized and are fallback values. Fallback parameters are labelled in the .itp files. Use with caution and verify results carefully.
 
 
 ;----------------------------------
@@ -238,6 +244,8 @@ BB  { "resname": "LA|LAL|LAD" }
 [ edges ]
 -BB BB
 BB +BB
+[ warning ]
+This force field is derived from Pannuzzo et al. Biomacromolecules 2022. Some parameters are not optimized and are fallback values. Fallback parameters are labelled in the .itp files. Use with caution and verify results carefully.
 
 [ link ]
 [ atoms ]
@@ -249,6 +257,8 @@ BB  { "resname": "GA" }
 [ edges ]
 -BB BB
 BB +BB
+[ warning ]
+This force field is derived from Pannuzzo et al. Biomacromolecules 2022. Some parameters are not optimized and are fallback values. Fallback parameters are labelled in the .itp files. Use with caution and verify results carefully.
 
 
 ;----------------------------------
@@ -267,6 +277,8 @@ BB   { "resname": "LA|LAL|LAD" }
 -BB BB
 BB +BB
 +BB ++BB
+[ warning ]
+This force field is derived from Pannuzzo et al. Biomacromolecules 2022. Some parameters are not optimized and are fallback values. Fallback parameters are labelled in the .itp files. Use with caution and verify results carefully.
 
 [ link ]
 [ atoms ]
@@ -280,3 +292,8 @@ BB   { "resname": "GA" }
 -BB BB
 BB +BB
 +BB ++BB
+[ warning ]
+This force field is derived from Pannuzzo et al. Biomacromolecules 2022. Some parameters are not optimized and are fallback values. Fallback parameters are labelled in the .itp files. Use with caution and verify results carefully.
+
+
+

--- a/polyply/data/martini2/citations.bib
+++ b/polyply/data/martini2/citations.bib
@@ -90,3 +90,14 @@
   year={2015},
   publisher={ACS Publications}
 }
+
+
+@article{M2_PLGA,
+  title={A Coarse-Grained Molecular Dynamics Description of Docetaxel-Conjugate Release from PLGA Matrices},
+  author={Pannuzzo, Martina and Felici, Alessia and Decuzzi, Paolo},
+  journal={Biomacromolecules},
+  volume={23},
+  number={11},
+  pages={4678-4686},
+  year={2022},
+}


### PR DESCRIPTION
Hi polyply team,

Re issue #456  - adding PLGA parameters for martini2.

This PR contains Martini2 parameters from [this paper by Pannuzzo et al.](https://pubs.acs.org/doi/10.1021/acs.biomac.2c00903)

I have included the available parameters from the SI for glycolic acid, L-lactic acid and D-lactic acid.

I also performed a validation similar to that in the SI - 100x64-mer PLGA chains (50:50 LA:GA) and achieved similar values for density, Radius of gyration and end to end distance as in their UA simulation and CG simulation. Attached the files used for this validation, with .itp for PLGA built from a sequence file.

Unfortunately the paper does not include parameters for GA-GA and LA-LA blocks so I have included some 'fallback' parameters for these. Aware this is not ideal and requires further optimisation. I also did a similation containing blocky PLGA sequences with GA-GA and LA-LA stretches and the use of the fallback parameters did not cause a deviation in density, RoG or e-e distance.

[PLGA_validation.zip](https://github.com/user-attachments/files/25602831/PLGA_validation.zip)

Also added the appropriate citation BibTeX.

Apologies if there is any oversight in these files. 
Thanks,

Hannah