### PR TITLE
Fix parametrize pytest9

### DIFF
--- a/polyply/tests/test_simple_seq_parsers.py
+++ b/polyply/tests/test_simple_seq_parsers.py
@@ -90,7 +90,7 @@ def test_monomers_to_linear_nx_graph(example_meta_molecule):
     seq_graph = _monomers_to_linear_nx_graph(monomers)
     assert nx.is_isomorphic(seq_graph, example_meta_molecule, node_match=_node_match)
 
-@pytest.mark.parametrize('extension, ', (
+@pytest.mark.parametrize('extension', (
       "txt",
       "ig",
       "fasta"
@@ -119,7 +119,7 @@ def test_ig_termination_fail():
     with pytest.raises(FileFormatError):
         seq_graph = MetaMolecule.parsers["ig"](filepath)
 
-@pytest.mark.parametrize('extension, ', (
+@pytest.mark.parametrize('extension', (
       "ig",
       "fasta"
      ))
@@ -155,4 +155,3 @@ def test_ig_warning(caplog):
             break
         else:
             assert False
-# temp: confirm pytest 9.1 reproduces the parametrize error (removed in next commit)

--- a/polyply/tests/test_simple_seq_parsers.py
+++ b/polyply/tests/test_simple_seq_parsers.py
@@ -155,3 +155,4 @@ def test_ig_warning(caplog):
             break
         else:
             assert False
+# temp: confirm pytest 9.1 reproduces the parametrize error (removed in next commit)


### PR DESCRIPTION
The test suite fails to collect under pytest 9.1 because two parametrize decorators in test_simple_seq_parsers.py have a stray trailing comma in the argnames string ('extension, '). pytest 9.0.x tolerated this; 9.1 treats the comma as multiple argnames and tries to unpack each value, so e.g. "txt" (3 chars) is read as 3 values for 1 name and collection errors out.

The 1st commit reproduces the failure on CI (pytest 9.1); commit 2 removes the trailing comma.

This is why the tests fail in: https://github.com/marrink-lab/polyply_1.0/pull/465
It's a recent update: my first couple of commits in https://github.com/marrink-lab/polyply_1.0/pull/465 were fine (pytest 9.0.x) but the commit of a few minutes ago fails because in the meantime there's pytest 9.1.