### PR TITLE
docs: add gen_ff  tutorial

### DIFF
--- a/docs/tutorials/ff_example/atomtype_reduction_oplsLigParGen.py
+++ b/docs/tutorials/ff_example/atomtype_reduction_oplsLigParGen.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+"""
+atomtype_reduction.py
+
+Use:
+./atomtype_reduction.py -f PEO_n4/system.top
+"""
+
+
+import numpy as np
+import argparse
+import re
+import sys
+import src.itp_handling as itp_handling 
+
+known_OPLS_atomtypes = {'opls_135' : ['3.50000E-01','2.76144E-01'], # CT - carbon   (1) aliphatic
+                        'opls_002' : ['2.96000E-01','8.78640E-01'], #    - oxygen   (1) carbonyl
+                        'opls_179' : ['2.90000E-01','5.85760E-01'], #    - oxygen   (2) ester
+                        'opls_003' : ['3.25000E-01','7.11280E-01'], # N  - nitrogen (1) "standard" (nitroxide, aromatic)
+                        'opls_761' : ['2.96000E-01','7.11280E-01'], # ON - oxygen   (3) nitroxide 
+                        'opls_140' : ['2.50000E-01','1.25520E-01'], # HC - hydrogen (1) "standard"
+                        'opls_145' : ['3.55000E-01','2.92880E-01'], # CA - carbon   (2) aromatic 
+                        'opls_146' : ['2.42000E-01','1.25520E-01'], # HA - hydrogen (2) aromatic
+                        'opls_154' : ['3.12000E-01','7.11280E-01'], # OH - oxygen   (4) alcohol
+                        'opls_004' : ['0.00000E+00','0.00000E+00'], #    - hydrogen (3) alcohol
+                        'opls_151' : ['3.40000E-01','1.25520E+00'], # Cl - chlorine
+                        'opls_760' : ['3.25000E-01','5.02080E-01'], # NO - nitrogen (2) nitro group
+                        'opls_812' : ['3.45000E-01','3.47272E-01'], #    - carbon   (3) 3-membered ring (e.g., oxiran) !! NOT in the oplsaa.ff/ffnonbonded.itp incl. in GMX !!
+                        'opls_202' : ['3.60000E-01','1.48532E+00'], # S  - sulphur  (1) aromatic
+                        'opls_349' : ['3.50000E-01','3.34720E-01'], # CB - carbon   (4) aromatic bonded to *only* other aromatics
+                        'opls_150' : ['3.55000E-01','3.17984E-01'], # C= - carbon   (4) double-bond; also C# and CM
+                        'opls_900' : ['3.30000E-01','7.11280E-01'], # NT - nitrogen (3) tertiary nitrogen
+                        'opls_164' : ['2.94000E-01','2.55224E-01'], # F  - fluorine (1) most common parameters in oplsaa.ff
+                        'opls_035' : ['3.55000E-01','1.04600E+00'], # S  - sulfur   (1) generic sulfur (most sulfur atoms have these LJ parameters in oplsaa.ff/ffnonbonded.itp)
+                        'oplsFlpg' : ['2.90000E-01','2.51040E-01'], # F' - fluorine (2) fluorine parameters in LigParGen !! NOT in the oplsaa.ff/ffnonbonded.itp incl. in GMX !!
+                        'oplsSIlpg': ['4.00000E-01','4.18400E-01']} # Si' - silicon (1) Silicon parameters (LigParGen) !! NOT in the oplsaa.ff/ffnonbonded.itp incl. in GMX !!
+
+
+# Parse the arguments
+parser = argparse.ArgumentParser(description='Read in charges from TOP file and prints them out along with their sum.')
+parser.add_argument('-f', '--top-file', required=True, type=str  , help='name of TOP file')
+args = parser.parse_args()
+TOP_FILE    = args.top_file 
+OUT_FILE    = 'system_OK.top' 
+print(f"\nReading data from {TOP_FILE}.")
+
+
+def replace_string_in_line(string_old, string_new, line):
+    """
+    Replaces "string_old" by "string_new" in that particular "line", i.e., works like UNIX's `sed` (on a single line).
+    """
+    return re.sub(string_old, string_new, line)
+
+
+def find_key(input_dict, value_1, value_2):
+    """
+    https://stackoverflow.com/questions/16588328/return-key-by-value-in-dictionary
+    """
+    key_set = {k for k, v in input_dict.items() if (v[0] == value_1 and v[1] == value_2)}
+    return list(key_set)
+
+
+def map_LigParGen_to_known_atomtypes(itpfile):
+    """
+    Returns a dictionary that maps the atomtypes read from the LigParGen-generated provided system.top
+    to the 'known_OPLS_atomtypes' dictionary defined at the top of this file.
+    """
+    with open(itpfile, "r") as inpfile:
+        lines = inpfile.readlines()
+        status = None
+        old_to_new_atomtype_mapping = {}
+
+        for line in lines:
+            elements = line.split()
+            if len(elements) != 0:
+                if line[0] == "[":
+                    status = itp_handling.check_itp_line(line)
+                    continue
+                elif status == 'atomtypes' and not elements[0] == ";" and not line[0] == '#':
+                    LigParGen_atomtype_name = line.split()[0]
+                    sig = line[45:80].split()[0]
+                    eps = line[45:80].split()[1]
+                    key = find_key(known_OPLS_atomtypes, sig, eps)
+
+                    if len(key) == 1:
+                        old_to_new_atomtype_mapping[LigParGen_atomtype_name] = key[0]
+                    elif len(key) > 1:
+                        sys.exit("Two matches found - why? Check the 'known_OPLS_atomtypes' dictionary.")
+                    else:
+                        sys.exit(f"NEW atomtype! {LigParGen_atomtype_name}, {sig}, {eps}; it needs to be added to the 'known_OPLS_atomtypes' dictionary.")
+        return old_to_new_atomtype_mapping
+
+
+print("INFO - step 1 - map LigParGen to known atomtypes")
+old_to_new_atomtype_mapping = map_LigParGen_to_known_atomtypes(TOP_FILE)
+
+
+print("INFO - step 2 - generate new [atoms] section")
+with open(TOP_FILE, "r") as inpfile:
+
+    lines = inpfile.readlines()
+    status = None
+    new_atom_lines = []
+
+    for line in lines:
+        elements = line.split()
+
+        for LigParGen_atomtype_name, new_atomtype_name in old_to_new_atomtype_mapping.items():
+
+            if len(elements) != 0:
+                if line[0] == "[":
+                    status = itp_handling.check_itp_line(line)
+                    continue
+                elif status == 'atoms' and not elements[0] == ";" and not line[0] == '#':
+                    if LigParGen_atomtype_name in line:
+                        newline = replace_string_in_line(LigParGen_atomtype_name, new_atomtype_name, line)
+                        new_atom_lines.append(newline)
+                elif status == 'bonds':
+                    break
+
+
+print("INFO - step 3 - write system_OK.top")
+with open(TOP_FILE, "r") as inpfile, open(OUT_FILE, "w") as outfile:
+
+    lines = inpfile.readlines()
+    status = None
+    atom_count = 0
+
+    for line in lines:
+        elements = line.split()
+        if len(elements) != 0:
+            if line[0] == "[":
+                status = itp_handling.check_itp_line(line)
+                outfile.write(line)
+                continue
+            elif status == 'atoms' and not elements[0] == ";" and not line[0] == '#':
+                outfile.write(new_atom_lines[atom_count])
+                atom_count = atom_count + 1 
+            else:
+                outfile.write(line)
+        else:
+            outfile.write(line)
+
+

--- a/docs/tutorials/ff_example/atomtype_reduction_oplsLigParGen.py
+++ b/docs/tutorials/ff_example/atomtype_reduction_oplsLigParGen.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 
 """
-atomtype_reduction.py
+atomtype_reduction_oplsLigParGen.py
 
 Use:
-./atomtype_reduction.py -f PEO_n4/system.top
+python atomtype_reduction_oplsLigParGen.py -f PEO_n4/system.top
 """
 
 
-import numpy as np
 import argparse
 import re
 import sys

--- a/docs/tutorials/ff_example/em.mdp
+++ b/docs/tutorials/ff_example/em.mdp
@@ -1,7 +1,7 @@
 ;
 ; ****  Gromacs run parameters for OPLS-AA simulations  ****
 ;
-; **** Energy minimazation
+; **** Energy minimization
 ; 
 ; References:
 ; - S. Riniker, J. Chem. Inf. Model. 2018, DOI: 10.1021/acs.jcim.8b00042

--- a/docs/tutorials/ff_example/em.mdp
+++ b/docs/tutorials/ff_example/em.mdp
@@ -1,0 +1,56 @@
+;
+; ****  Gromacs run parameters for OPLS-AA simulations  ****
+;
+; **** Energy minimazation
+; 
+; References:
+; - S. Riniker, J. Chem. Inf. Model. 2018, DOI: 10.1021/acs.jcim.8b00042
+; - L.S. Dodda, et al., Nucleic Acids Res. 2017, DOI: 10.1093/nar/gkx312
+; - C. Caleman, et al., J. Chem. Theory. Comput. 2021, DOI: 10.1021/ct200731v 
+;
+
+; Integrator
+integrator               = steep             ; steepest descent E minimization
+nsteps                   = 5000
+emtol                    = 100               ; default 
+constraint_algorithm     = lincs             ; default
+constraints              = none
+lincs_order              = 4                 ; default
+
+; Output Control
+nstxout                  = 500000            ; pos out   ---  1000  ps
+nstvout                  = 500000            ; vel out   ---  1000  ps
+nstfout                  = 0                 ; force out ---  no
+nstlog                   = 10000             ; energies to log (20 ps)
+nstenergy                = 10000             ; energies to energy file
+energygrps               = System
+nstxtcout                = 10000             ; xtc, 10 ps
+compressed-x-precision   = 1000              ; default is 1000
+
+; Some specific settings
+pbc                      = xyz
+periodic_molecules       = no                ; default
+comm_mode                = Linear
+
+; Neighboring search and cutoff scheme
+cutoff-scheme            = Verlet
+nstlist                  = 10                ; default
+ns-type                  = grid
+rlist                    = 1.1               ; ignored with Verlet
+
+; Coulombic
+coulombtype              = PME
+rcoulomb                 = 1.1   
+fourierspacing           = 0.12              ; default
+
+; VDW
+vdwtype                  = cut-off
+rvdw                     = 1.1    
+DispCorr                 = EnerPres          ; long-range correction
+
+; Temperature Coupling
+tcoupl                   = no
+
+; Pressure Coupling
+Pcoupl                   = no 
+

--- a/docs/tutorials/ff_example/src/itp_handling.py
+++ b/docs/tutorials/ff_example/src/itp_handling.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import sys
+
+def check_itp_line(line):
+    """
+    Checks which Gromacs section of the itp file we are at, returning a 'status' accordingly.
+
+    Parameters
+    ----------
+    line: string
+        A line of the itp file received as input file.
+
+    Returns
+    --------
+    status: string
+        A string which tells in which section of the itp we are. 
+    """
+    if 'defaults' in line:
+        return 'defaults'
+    elif 'atomtypes' in line:
+        return 'atomtypes'
+    elif 'system' in line:
+        return 'system'
+    elif 'molecules' in line:
+        return 'molecules'
+    elif 'moleculetype' in line:
+        return 'mtype'
+    elif 'atoms' in line:
+        return 'atoms'
+    elif 'virtual_sitesn' in line:
+        return 'virtual_sitesn'
+    elif 'bonds' in line:
+        return 'bonds'
+    elif 'constraints' in line:
+        return 'constraints'
+    elif 'pairs' in line:
+        return 'pairs'
+    elif 'angles' in line:
+        return 'angles'
+    elif 'exclusions' in line:
+        return 'exclusions'
+    elif 'dihedrals' in line:
+        return 'dihedrals'
+    elif 'link' in line:
+        return 'link'
+    else:
+        sys.exit('! ERROR ! Something is wrong. Just found the following line in the input itp file: ' + line)
+

--- a/docs/tutorials/ff_example/system_test.top
+++ b/docs/tutorials/ff_example/system_test.top
@@ -1,0 +1,13 @@
+; Include forcefield parameters
+#include "/absolute-path-to/share/gromacs/top/oplsaa.ff/forcefield.itp"
+
+; Include topologies
+#include "PS_n5_test.itp"
+
+[ system ]
+; Name
+Test
+
+[ molecules ]
+; Compound        #mols
+PS                  1

--- a/docs/tutorials/gen-ff.md
+++ b/docs/tutorials/gen-ff.md
@@ -27,7 +27,7 @@ and visualize structures [here](https://pubchem.ncbi.nlm.nih.gov/edit3/index.htm
 ## Prerequisites
 
 - A SMILES string or PDB file for your pentamer
-- [UV](https://docs.astral.sh/uv/#highlights) or Conda installed
+- A virtual-environment manager (e.g. [uv](https://docs.astral.sh/uv/#highlights) or conda)
 - Python 3.x
 
 ---
@@ -76,31 +76,27 @@ Lennard-Jones parameters (σ and ε).
 
 ## 2. Installation
 
-We need two environments: one for `gen_ff` (a development branch of polyply used
-to generate the `.ff` file) and one for the stable polyply release (used for all
-subsequent polyply steps such as `gen_params` and `gen_coords`).
+The whole tutorial runs in a **single environment** built from the `gen_ff_clean`
+development branch of polyply, which provides `gen_ff` alongside the standard
+`gen_params` and `gen_coords`.
 
-**With UV** (recommended):
-```bash
-uv venv gen_ff --python 3.11
-source gen_ff/bin/activate 
-uv pip install git+https://github.com/gruenewald-lab/CGsmiles.git
-uv pip install scipy matplotlib shapely pytest
-git clone https://github.com/marrink-lab/polyply_1.0.git
-cd polyply_1.0
-git checkout gen_ff_clean            # development branch
-uv pip install -e .
-```
+Create a virtual environment with your favourite environment manager (for example
+[uv](https://docs.astral.sh/uv/) or conda), then install polyply from the
+`gen_ff_clean` branch together with its dependencies:
 
-**With Conda**:
 ```bash
-conda create -n gen_ff python=3.11
-conda activate gen_ff
+# 1. Create and activate an environment (Python 3.11), e.g.
+#      uv:    uv venv gen_ff --python 3.11 && source gen_ff/bin/activate
+#      conda: conda create -n gen_ff python=3.11 && conda activate gen_ff
+
+# 2. Install CGsmiles and the other dependencies
 pip install git+https://github.com/gruenewald-lab/CGsmiles.git
 pip install scipy matplotlib shapely pytest
+
+# 3. Install polyply from the development branch
 git clone https://github.com/marrink-lab/polyply_1.0.git
 cd polyply_1.0
-git checkout gen_ff_clean            # development branch
+git checkout gen_ff_clean        # development branch (see warning above)
 pip install -e .
 ```
 
@@ -108,19 +104,6 @@ pip install -e .
 
     `gen_ff_clean` is a development branch — expect experimental features and
     potential breaking changes (see the warning at the top of this page).
-
-For the stable polyply environment (needed for validation and all downstream steps):
-```bash
-# UV
-uv venv polyply-stable --python 3.11
-source polyply-stable/bin/activate
-uv pip install polyply
-
-# Conda
-conda create -n polyply-stable python=3.11
-conda activate polyply-stable
-pip install polyply
-```
 
 ---
 
@@ -190,9 +173,8 @@ Key flags:
 
 ### Example 1: Polystyrene (PS)
 
-PS is a simple vinyl polymer with a styrene repeat unit. Its repeat unit is small
-enough that a full 5-mer fits within LigParGen's 200-atom limit.
-This makes it a clean, minimal case to get familiar with the workflow.
+PS is a good first case: its styrene repeat unit is small, so a full 5-mer fits
+within LigParGen's 200-atom limit (no trimming needed, as discussed above).
 
 **SMILES for LigParGen** (5-mer with methyl terminals):
 ```
@@ -244,7 +226,7 @@ files, both provided alongside this tutorial in `docs/tutorials/ff_example/`:
     sufficient here.
 
 ```bash
-source polyply-stable/bin/activate   # or: conda activate polyply-stable
+source gen_ff/bin/activate   # or: conda activate gen_ff
 
 polyply gen_params -f PS.ff -seq CH3:1 PS:5 CH3:1 -o PS_n5_test.itp -name PS
 polyply gen_coords -p system_test.top -o system_test.gro -name PS -box 5 5 5

--- a/docs/tutorials/gen-ff.md
+++ b/docs/tutorials/gen-ff.md
@@ -1,0 +1,254 @@
+# Tutorial: Generating an arbitrary force field for a polymer
+
+## Introduction
+
+This guide explains how to generate an OPLS-AA atomistic force field for a polymer,
+using [LigParGen](https://zarbi.chem.yale.edu/ligpargen/) and
+[`polyply gen_ff`](https://github.com/marrink-lab/polyply_1.0).
+
+!!! warning "`gen_ff` is not in a stable release yet"
+
+    This workflow relies on `polyply gen_ff`, which currently lives only on the
+    experimental **`gen_ff_clean`** development branch (see the installation step
+    below). Expect experimental features and potential breaking changes, and be
+    aware that commands and flags shown here may change before `gen_ff` is
+    included in an official polyply release.
+
+**Why OPLS-AA?** While it is a relatively widely used force field for non-biological
+organic molecules, the choice of OPLS-AA here is completely arbitrary and the workflow is force-field agnostic.
+It could have been GAFF2, OpenFF, etc.
+
+**What is SMILES?** SMILES is a text notation for chemical structures.
+You can find a [notation explainer here](https://matlantis.com/en/resources/blog/how-to-write-smiles/)
+and visualize structures [here](https://pubchem.ncbi.nlm.nih.gov/edit3/index.html).
+
+---
+
+## Prerequisites
+
+- A SMILES string or PDB file for your pentamer
+- [UV](https://docs.astral.sh/uv/#highlights) or Conda installed
+- Python 3.x
+
+---
+
+## 1. LigParGen
+
+We use the [LigParGen server](https://zarbi.chem.yale.edu/ligpargen/) to generate
+an initial force field in OPLS-AA format from a small-molecule fragment of the polymer.
+
+### The 200-atom limit and the trimmed-fragment strategy
+
+LigParGen only supports molecules of up to 200 atoms. For polymers, this means
+we cannot upload the full chain. However, we need at least 3–4 repeating units to
+correctly capture the dihedral environment of the central repeat unit.
+
+The solution is to upload a **trimmed fragment**: one complete central repeating unit
+flanked by 2 units on each side. This captures the correct dihedral environment
+without exceeding the atom limit. For polymers with short repeat units (e.g. PS,
+see Example 1), a full 5-mer fits comfortably within the 200-atom limit.
+See special cases below if a 5-mer exceeds the 200-atom limit.
+
+For example, the SMILES string below represents a 5-mer PS chain: 
+```
+CCC(c1ccccc1)CC(c1ccccc1)CC(c1ccccc1)CC(c1ccccc1)CC(c1ccccc1)C
+```
+Note that the PS monomer is `CC(c1ccccc1)` and the string is terminated on both sides
+by two methyl gropus (`C`).
+
+
+### Generating the force field
+
+1. Paste your SMILES string into the LigParGen input field.
+2. Under **charge model**, select **(neutral or charged molecules)**.
+3. Click **Submit Molecule**.
+4. Download:
+   - **TOP for Gromacs** (`.itp`) — force field topology
+   - **PDB** — 3D structure
+
+### Structure of the ITP file
+
+The ITP file contains several sections. The most important for our purposes is
+**`[ atomtypes ]`**, which defines atom type names and their associated
+Lennard-Jones parameters (σ and ε).
+
+---
+
+## 2. Installation
+
+We need two environments: one for `gen_ff` (a development branch of polyply used
+to generate the `.ff` file) and one for the stable polyply release (used for all
+subsequent polyply steps such as `gen_params` and `gen_coords`).
+
+**With UV** (recommended):
+```bash
+uv venv gen_ff --python 3.11
+source gen_ff/bin/activate 
+uv pip install git+https://github.com/gruenewald-lab/CGsmiles.git
+uv pip install scipy matplotlib shapely pytest
+git clone git@github.com:marrink-lab/polyply_1.0.git
+cd polyply_1.0
+git checkout gen_ff_clean            # development branch
+uv pip install -e .
+```
+
+**With Conda**:
+```bash
+conda create -n gen_ff python=3.11
+conda activate gen_ff
+pip install git+https://github.com/gruenewald-lab/CGsmiles.git
+pip install scipy matplotlib shapely pytest
+git clone git@github.com:marrink-lab/polyply_1.0.git
+cd polyply_1.0
+git checkout gen_ff_clean            # development branch
+pip install -e .
+```
+
+!!! note
+
+    `gen_ff_clean` is a development branch — expect experimental features and
+    potential breaking changes (see the warning at the top of this page).
+
+For the stable polyply environment (needed for validation and all downstream steps):
+```bash
+# UV
+uv venv polyply-stable --python 3.11
+source polyply-stable/bin/activate
+uv pip install polyply
+
+# Conda
+conda create -n polyply-stable python=3.11
+conda activate polyply-stable
+pip install polyply
+```
+
+---
+
+## 3. Atom type relabeling
+
+LigParGen assigns its own internal atom type names rather than the standard OPLS-AA
+labels that GROMACS expects. The script `atomtype_reduction_oplsLigParGen.py` fixes
+this: it matches each atom type's Lennard-Jones parameters against a dictionary of
+known OPLS-AA types and rewrites the topology with the correct labels,
+outputting `system_OK.top`.
+
+Both scripts ship with this documentation, under `docs/tutorials/ff_example/` in the
+polyply repository you already cloned above — `atomtype_reduction_oplsLigParGen.py`
+(available [here](./ff_example/atomtype_reduction_oplsLigParGen.py)) together with its
+helper `itp_handling.py`, which must sit in a `src/` subfolder relative to it (as it does
+in the repository).
+
+```bash
+./atomtype_reduction_oplsLigParGen.py -f <your_file>_LigParGen.itp
+mv system_OK.top <your_file>_LigParGen_OK.itp
+```
+
+Then remove or comment out the entire `[ atomtypes ]` section from the `_OK.itp`
+and save as `_clean.itp`. This section is stripped because GROMACS expects atomtypes
+to be defined once at the system level (in the `.top` file), not repeated in each `.itp`.
+
+---
+
+## 4. CGsmiles string
+
+CGsmiles describes polymer topology at two levels. For example, for PS:
+
+```
+{[#CH3][#PS]|5[#CH3]}.{#CH3=C[>][<],#PS=[>]CC(c1ccccc1)[<]}
+```
+
+- The first `{...}` block is the **polymer-level** graph: repeat units and their
+  connectivity (`|5` means 5 repetitions of `#PS`)
+- The second `{...}` block is the **monomer-level** graph: each unit defined by its
+  SMILES string, with `[>]` and `[<]` denoting inter-unit bond attachment points
+
+See the [CGsmiles documentation](https://cgsmiles.readthedocs.io/en/latest/gettingstarted/syntax_examples.html)
+and [publication](https://pubs.acs.org/doi/10.1021/acs.jcim.5c00064) for full syntax details.
+
+---
+
+## 5. Running `polyply gen_ff`
+
+```bash
+source gen_ff/bin/activate   # or: conda activate gen_ff
+
+polyply gen_ff -i <your_file>_LigParGen_clean.itp \
+               -s "<CGsmiles string>" \
+               -c <monomer1>:0 <monomer2>:0 ... \
+               -o <polymer>.ff
+```
+
+Key flags:
+- `-i` — input `.itp` file (**use the `_clean.itp` version**)
+- `-s` — CGsmiles string
+- `-c` — charge per monomer residue (e.g. `PS:0` for neutral)
+- `-o` — output `.ff` filename
+
+---
+
+## Examples
+
+### Example 1: Polystyrene (PS)
+
+PS is a simple vinyl polymer with a styrene repeat unit. Its repeat unit is small
+enough that a full 5-mer fits within LigParGen's 200-atom limit.
+This makes it a clean, minimal case to get familiar with the workflow.
+
+**SMILES for LigParGen** (5-mer with methyl terminals):
+```
+CCC(c1ccccc1)CC(c1ccccc1)CC(c1ccccc1)CC(c1ccccc1)CC(c1ccccc1)C
+```
+
+Download and relabel atomtypes as described in Sections 1 and 3, saving the
+final cleaned file as `PS_n5_LigParGen_clean.itp`.
+
+**CGsmiles string:**
+```
+{[#CH3][#PS]|5[#CH3]}.{#CH3=C[>][<],#PS=[>]CC(c1ccccc1)[<]}
+```
+
+**Running `gen_ff`:**
+```bash
+source gen_ff/bin/activate
+
+polyply gen_ff -i PS_n5_LigParGen_clean.itp \
+               -s "{[#CH3][#PS]|5[#CH3]}.{#CH3=C[>][<],#PS=[>]CC(c1ccccc1)[<]}" \
+               -c CH3:0 PS:0 -o PS.ff
+```
+
+**Validation:**
+
+To generate coordinates and run a quick energy minimization you need two more input
+files, both provided alongside this tutorial in `docs/tutorials/ff_example/`:
+
+- [`system_test.top`](./ff_example/system_test.top) — the system topology. It includes
+  the OPLS-AA force field and the itp generated by `gen_params` below (`PS_n5_test.itp`),
+  and lists a single `PS` molecule.
+- [`em.mdp`](./ff_example/em.mdp) — a standard steepest-descent energy-minimization
+  parameter file.
+
+!!! warning "Set the OPLS-AA force-field path in `system_test.top`"
+
+    `system_test.top` includes the OPLS-AA force field with a placeholder path:
+
+    ```
+    #include "/absolute-path-to/share/gromacs/top/oplsaa.ff/forcefield.itp"
+    ```
+
+    `gen_coords` resolves this include using the **absolute path**, so it cannot be
+    known in advance — it depends on your GROMACS installation. Before running the
+    commands below, replace `/absolute-path-to/` with the actual location of your
+    GROMACS `top` directory (for example `/usr/local/gromacs/share/gromacs/top/...`;
+    if `gmx` is on your `PATH`, the command `$(dirname $(which gmx))/../share/gromacs/top`
+    resolves to it). A relative `#include "oplsaa.ff/forcefield.itp"` is **not**
+    sufficient here.
+
+```bash
+source polyply-stable/bin/activate   # or: conda activate polyply-stable
+
+polyply gen_params -f PS.ff -seq CH3:1 PS:5 CH3:1 -o PS_n5_test.itp -name PS
+polyply gen_coords -p system_test.top -o system_test.gro -name PS -box 5 5 5
+gmx grompp -p system_test.top -c system_test.gro -f em.mdp -o 1-em
+gmx mdrun -v -deffnm 1-em
+```
+

--- a/docs/tutorials/gen-ff.md
+++ b/docs/tutorials/gen-ff.md
@@ -54,7 +54,7 @@ For example, the SMILES string below represents a 5-mer PS chain:
 CCC(c1ccccc1)CC(c1ccccc1)CC(c1ccccc1)CC(c1ccccc1)CC(c1ccccc1)C
 ```
 Note that the PS monomer is `CC(c1ccccc1)` and the string is terminated on both sides
-by two methyl gropus (`C`).
+by two methyl groups (`C`).
 
 
 ### Generating the force field
@@ -86,7 +86,7 @@ uv venv gen_ff --python 3.11
 source gen_ff/bin/activate 
 uv pip install git+https://github.com/gruenewald-lab/CGsmiles.git
 uv pip install scipy matplotlib shapely pytest
-git clone git@github.com:marrink-lab/polyply_1.0.git
+git clone https://github.com/marrink-lab/polyply_1.0.git
 cd polyply_1.0
 git checkout gen_ff_clean            # development branch
 uv pip install -e .
@@ -98,7 +98,7 @@ conda create -n gen_ff python=3.11
 conda activate gen_ff
 pip install git+https://github.com/gruenewald-lab/CGsmiles.git
 pip install scipy matplotlib shapely pytest
-git clone git@github.com:marrink-lab/polyply_1.0.git
+git clone https://github.com/marrink-lab/polyply_1.0.git
 cd polyply_1.0
 git checkout gen_ff_clean            # development branch
 pip install -e .
@@ -139,7 +139,7 @@ helper `itp_handling.py`, which must sit in a `src/` subfolder relative to it (a
 in the repository).
 
 ```bash
-./atomtype_reduction_oplsLigParGen.py -f <your_file>_LigParGen.itp
+python ./docs/tutorials/ff_example/atomtype_reduction_oplsLigParGen.py -f <your_file>_LigParGen.itp
 mv system_OK.top <your_file>_LigParGen_OK.itp
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
   - Tutorials:
       - Martini Polymers: tutorials/martini-polymers.md
       - GROMOS Polymer Melts: tutorials/gromos-polymer-melts.md
+      - Generating a Force Field: tutorials/gen-ff.md
       - PEGylated Lipid Bilayers: tutorials/pegylated-lipid-bilayers.md
       - Single-Stranded DNA: tutorials/single-stranded-dna.md
       - Martini 3 IDPs / Proteins: tutorials/martini3-idps-proteins.md


### PR DESCRIPTION
Add a tutorial on generating an arbitrary (OPLS-AA by example) polymer force field with LigParGen and polyply gen_ff, wired into the Tutorials nav. Include the helper scripts and validation inputs it references under docs/tutorials/ff_example/ (atomtype relabeling scripts, system_test.top, em.mdp).