### PR TITLE
docs: fix broken polymer-library links and add moleculetype deep-links

### DIFF
--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -4,9 +4,9 @@
 |Polyethylene oxide             |PEO                      |[gromos2016H66](polyply/data/2016H66/polyether_blocks.ff)              | [martini2](polyply/data/martini2/PEO.martini.2.itp)   |
 |                               |                         |[oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEO.oplsaa.LigParGen.ff)| [martini3](polyply/data/martini3/PEO.martini3.ff)     |
 |Polystyrene                    |PS                       |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              | [martini2](polyply/data/martini2/PS.martini.2.itp)    |
-|                               |                         |                                                                       | [martini3](polyply/data/martini3/PS.martini3.ff)      |
+|                               |                         |                                                                       | [martini3 (STYR)](polyply/data/martini3/vinyl_polymers.ff#mol=STYR)      |
 |Polystyrene-b-poly(ethylene oxide)|PS-PEO                |                                                                       | [martini3](polyply/data/martini3/PS_PEO_link.ff)      |
-|Polymethyl acrylate            |PMA                      |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              | [martini3](polyply/data/martini3/PMA.martini3.ff)     |
+|Polymethyl acrylate            |PMA                      |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              | [martini3 (MAC)](polyply/data/martini3/vinyl_polymers.ff#mol=MAC)     |
 |Polymethyl methacrylate        |PMMA                     |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              | [martini3](polyply/data/martini3/PMMA.martini3.ff)    |
 |Polyethylene                   |PE                       |[gromos2016H66](polyply/data/2016H66/polyvinyl_blocks.ff)              | [martini3](polyply/data/martini3/PE.martini3.ff)      |
 |                               |                         |                                                                       | [martini2](polyply/data/martini2/PE.martini.2.itp)    |
@@ -22,7 +22,7 @@
 |                               |                         |                                                                       | [martini3](polyply/data/martini3/PSS.martini3.ff)     |
 |Poly(para-phenylene ethynylene)|PPE                      |                                                                       | [martini3](polyply/data/martini3/PPE.martini3.ff)     |
 |Poly(TEMPO methacrylate)       |PTMA                     |[oplsaaLigParGen](polyply/data/oplsaaLigParGen/PTMA.oplsaa.LigParGen.ff)| [martini3](polyply/data/martini3/PTMA.martini3.ff)   |
-|                               |                         |                                                                       | [ibi_cgm3](polyply/data/ibi_cmg3/PTMA.cgm3.ibi.ff)    |
+|                               |                         |                                                                       | [ibi_cgm3](polyply/data/ibi_cgm3/PTMA.cgm3.ibi.ff)    |
 |                               |                         |                                                                       | [ibi_gbcg](polyply/data/ibi_gbcg/PTMA.gbno2.ibi.ff)   |
 |poly(N-(methacryloxyethyl) phthalimide)|PMAP             |[oplsaaLigParGen](polyply/data/oplsaaLigParGen/PMAP_and_PMAPcharged.oplsaa.LigParGen.ff)|                                      |
 |poly(2,3-epoxy-propylphthalimide)|PEPP                   |[oplsaaLigParGen](polyply/data/oplsaaLigParGen/PEPP_and_PEPPcharged.oplsaa.LigParGen.ff)|                                      |

--- a/docs_hooks/include_library.py
+++ b/docs_hooks/include_library.py
@@ -29,6 +29,9 @@ from pathlib import Path
 TARGET_PAGE = "reference/polymer-library.md"
 PLACEHOLDER = "{{ LIBRARY }}"
 
+# Comment character in the .ff / .itp files (everything after it is ignored).
+COMMENT_CHAR = ";"
+
 # Matches markdown links whose target is a path inside the polyply package data,
 # with an optional "#mol=NAME" fragment used to deep-link to one moleculetype
 # inside a file that bundles several (e.g. vinyl_polymers.ff).
@@ -61,30 +64,33 @@ def _source_ref():
 
 
 def _moleculetype_line(ff_path, name):
-    """1-based line of the ``[ moleculetype ]`` entry called *name*, or ``None``.
+    """1-based line of the ``[ moleculetype ]`` header for *name*, or ``None``.
 
-    Anchors on the line carrying the molecule name (the first non-comment,
-    non-blank line after a ``[ moleculetype ]`` header) -- exactly what a reader
-    would search the file for. Used to turn ``vinyl_polymers.ff#mol=STYR`` into a
+    Returns the header line so the anchor lands on the ``[ moleculetype ]``
+    directive that starts the block; the molecule name is on the next
+    (non-comment) line. Used to turn ``vinyl_polymers.ff#mol=STYR`` into a
     ``#L<line>`` deep link. Because the surrounding links are pinned to the build
     revision, the resolved line number stays valid for that published page.
+
+    Inline comments are stripped first, so a ``[ moleculetype ] ; note`` header
+    or a ``STYR 3 ; note`` name line still match.
     """
     try:
         lines = ff_path.read_text(encoding="utf-8").splitlines()
     except OSError:
         return None
-    in_block = False
+    header_lineno = None
     for lineno, raw in enumerate(lines, start=1):
-        stripped = raw.strip()
-        if stripped.lower().replace(" ", "") == "[moleculetype]":
-            in_block = True
+        code = raw.split(COMMENT_CHAR, 1)[0].strip()  # drop any inline comment
+        if code.lower().replace(" ", "") == "[moleculetype]":
+            header_lineno = lineno
             continue
-        if in_block:
-            if not stripped or stripped.startswith(";"):
-                continue  # skip blanks/comments between the header and the name
-            in_block = False
-            if stripped.split()[0] == name:
-                return lineno
+        if header_lineno is not None:
+            if not code:
+                continue  # skip blanks/comment-only lines between header and name
+            if code.split()[0] == name:
+                return header_lineno
+            header_lineno = None  # a different molecule; keep looking
     return None
 
 

--- a/docs_hooks/include_library.py
+++ b/docs_hooks/include_library.py
@@ -29,8 +29,10 @@ from pathlib import Path
 TARGET_PAGE = "reference/polymer-library.md"
 PLACEHOLDER = "{{ LIBRARY }}"
 
-# Matches markdown links whose target is a path inside the polyply package data.
-_REL_LINK = re.compile(r"\]\((polyply/data/[^)]+)\)")
+# Matches markdown links whose target is a path inside the polyply package data,
+# with an optional "#mol=NAME" fragment used to deep-link to one moleculetype
+# inside a file that bundles several (e.g. vinyl_polymers.ff).
+_REL_LINK = re.compile(r"\]\((polyply/data/[^)#]+)(?:#mol=([^)]+))?\)")
 
 
 @lru_cache(maxsize=None)
@@ -58,6 +60,34 @@ def _source_ref():
         return "master"
 
 
+def _moleculetype_line(ff_path, name):
+    """1-based line of the ``[ moleculetype ]`` entry called *name*, or ``None``.
+
+    Anchors on the line carrying the molecule name (the first non-comment,
+    non-blank line after a ``[ moleculetype ]`` header) -- exactly what a reader
+    would search the file for. Used to turn ``vinyl_polymers.ff#mol=STYR`` into a
+    ``#L<line>`` deep link. Because the surrounding links are pinned to the build
+    revision, the resolved line number stays valid for that published page.
+    """
+    try:
+        lines = ff_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    in_block = False
+    for lineno, raw in enumerate(lines, start=1):
+        stripped = raw.strip()
+        if stripped.lower().replace(" ", "") == "[moleculetype]":
+            in_block = True
+            continue
+        if in_block:
+            if not stripped or stripped.startswith(";"):
+                continue  # skip blanks/comments between the header and the name
+            in_block = False
+            if stripped.split()[0] == name:
+                return lineno
+    return None
+
+
 def on_page_markdown(markdown, page, config, files):
     # Special case for the library page only: it carries a {{ LIBRARY }} placeholder,
     # which we replace with the contents of the repo-root LIBRARY.md (the single source
@@ -72,5 +102,16 @@ def on_page_markdown(markdown, page, config, files):
     # site no matter which page it appears on (the library listing, a tutorial, ...).
     # Derive the blob base from repo_url so it tracks the source repo even when the
     # docs site itself is published elsewhere (e.g. a different org's GitHub Pages).
+    repo_root = Path(config["docs_dir"]).parent
     blob_base = f"{config['repo_url'].rstrip('/')}/blob/{_source_ref()}/"
-    return _REL_LINK.sub(lambda m: f"]({blob_base}{m.group(1)})", markdown)
+
+    def _rewrite(match):
+        path, mol = match.group(1), match.group(2)
+        anchor = ""
+        if mol:
+            lineno = _moleculetype_line(repo_root / path, mol)
+            if lineno:
+                anchor = f"#L{lineno}"
+        return f"]({blob_base}{path}{anchor})"
+
+    return _REL_LINK.sub(_rewrite, markdown)


### PR DESCRIPTION
Fixes three broken links in the polymer library table (`LIBRARY.md`, rendered on the [Polymer Library](https://polyply.github.io/polyply_1.0/reference/polymer-library/) docs page):

- **PTMA / ibi_cgm3** : directory typo in the URL (`ibi_cmg3` --> `ibi_cgm3`); the file exists at the corrected path.
- **PS / martini3** : `PS.martini3.ff` was removed; params now live in `vinyl_polymers.ff` (moleculetype `STYR`).
- **PMA / martini3**: `PMA.martini3.ff` was removed; params now in `vinyl_polymers.ff` (moleculetype `MAC`).

The PS/PMA links are repointed to `vinyl_polymers.ff` and labelled with the target moleculetype so readers know which residue applies inside the bundled file. See snapshot:
<img width="669" height="172" alt="Screen Shot 2026-07-06 at 10 39 12 PM" src="https://github.com/user-attachments/assets/bba91080-18ec-4f94-afbe-8dc100f80110" />

## Deep-links into bundled files

Since PS and PMA now share one file with a bunch of other polymers, I taught the build hook (`docs_hooks/include_library.py`) a small trick: if a link ends in `#mol=NAME`, it turns that into a `#L<line>` jump straight to that molecule's `[ moleculetype ]` block. So clicking "martini3 (STYR)" drops you right on the polystyrene block instead of the top of a 600-line file. The line number is worked out from the exact file version the docs were built from, so it won't drift out of date.
